### PR TITLE
Switch to use sphinx-book-theme 1.0.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,6 @@ build-backend = "setuptools.build_meta"
 name = 'rocm-docs-core'
 version = "0.0.1"
 description ='Core utilities for all ROCm documentation on RTD'
-authors = [
-  "Lauren Wrubleski <lauren.wrubleski@amd.com>"
-]
 dependencies = [
   "GitPython>=3.1.30,<3.2",
   "importlib_resources>=5.10.2,<5.11",
@@ -26,3 +23,4 @@ dependencies = [
   "myst_nb==0.17.1",
   "myst-parser[linkify]==0.18.1",
 ]
+requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,12 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [project]
+name = 'rocm-docs-core'
+version = "0.0.1"
+description ='Core utilities for all ROCm documentation on RTD'
+authors = [
+  "Lauren Wrubleski <lauren.wrubleski@amd.com>"
+]
 dependencies = [
   "GitPython>=3.1.30,<3.2",
   "importlib_resources>=5.10.2,<5.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,19 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+dependencies = [
+  "GitPython>=3.1.30,<3.2",
+  "importlib_resources>=5.10.2,<5.11",
+  "PyGithub==1.57",
+  "docutils==0.16",
+  "sphinx==4.3.1",
+  "breathe==4.34.0",
+  "sphinx-design==0.3.0",
+  "sphinx-copybutton==0.5.1",
+  "sphinx_external_toc==0.3.1",
+  "sphinx-book-theme==1.0.0rc2",
+  "myst_nb==0.17.1",
+  "myst-parser[linkify]==0.18.1",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,12 @@
 GitPython>=3.1.30, <3.2
 importlib_resources>=5.10.2, <5.11
 PyGithub==1.57
+docutils==0.16
+sphinx==4.3.1
+breathe==4.34.0
+sphinx-design==0.3.0
+sphinx-copybutton==0.5.1
+sphinx_external_toc==0.3.1
+sphinx-book-theme==1.0.0rc2
+myst_nb==0.17.1
+myst-parser[linkify]==0.18.1

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -77,7 +77,7 @@ class ROCmDocs:
         self.html_css_files: List[str]
         self.html_js_files: List[str]
         self.html_extra_path: List[str]
-        self.html_theme_options: Dict[str, Union[str, bool]]
+        self.html_theme_options: Dict[str, Union[str, bool, List[str]]]
         self.html_show_sphinx: bool
         self.html_favicon: str
         self._docs_folder: Path
@@ -261,7 +261,10 @@ class ROCmDocs:
             "show_navbar_depth": "2",
             "body_max_width": "none",
             "show_toc_level": "0",
-            "extra_navbar": "",
+            "article_header_start": [
+                "toggle-primary-sidebar.html",
+                "breadcrumbs.html"
+            ]
         }
 
         self.html_show_sphinx = False

--- a/src/rocm_docs/data/_static/custom.css
+++ b/src/rocm_docs/data/_static/custom.css
@@ -68,4 +68,5 @@ img#rdc-watermark {
 
 ul.bd-breadcrumbs {
     margin-bottom: 0;
+    margin-top: 1px;
 }

--- a/src/rocm_docs/data/_static/custom.css
+++ b/src/rocm_docs/data/_static/custom.css
@@ -65,3 +65,7 @@ img#rdc-watermark {
     object-fit: contain;
     width: 45%;
 }
+
+ul.bd-breadcrumbs {
+    margin-bottom: 0;
+}

--- a/src/rocm_docs/data/_static/rocm_header.css
+++ b/src/rocm_docs/data/_static/rocm_header.css
@@ -3,7 +3,7 @@
     position: -webkit-sticky; /* Safari */
     position: sticky;
     top: 0;
-    max-width: 100%;
+    width: 100%;
     min-height: 50px;
     overflow: hidden;
     font-family: 'Noto Sans', sans-serif;


### PR DESCRIPTION
The current version of `sphinx-book-theme` does not allow for breadcrumbs. Version 1.0.0 will, but is currently in the release candidate stage.