### PR TITLE
Accomodate private repos without token

### DIFF
--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -307,11 +307,3 @@ class ROCmDocs:
 
         pkg = importlib_resources.files("rocm_docs")
         copy_from_package(pkg / "data", "data", ".")
-
-
-def setup(app: Sphinx):
-    """Set up rocm_docs_core as a Sphinx extension as well.
-
-    Args:
-        app (Sphinx): Sphinx application to access the API.
-    """

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import BinaryIO, List, Optional, Union, Dict, Tuple
-from .util import format_toc, get_path_to_docs
+from .util import format_toc, get_branch, get_path_to_docs
 
 
 if sys.version_info < (3, 9):
@@ -214,7 +214,8 @@ class ROCmDocs:
                 f"Expected input toc file {toc_in_path} to exist and be"
                 " readable."
             )
-        url, branch = format_toc(self._docs_folder)
+        format_toc(self._docs_folder)
+        url, branch, edit_page = get_branch(self._docs_folder)
 
         self.external_toc_path = "./.sphinx/_toc.yml"
         self.external_toc_exclude_missing = False
@@ -255,7 +256,7 @@ class ROCmDocs:
         self.html_extra_path = ["_images"]
         self.html_theme_options = {
             "home_page_in_toc": False,
-            "use_edit_page_button": True,
+            "use_edit_page_button": edit_page,
             "repository_url": url,
             "repository_branch": branch,
             "path_to_docs": get_path_to_docs(),
@@ -306,3 +307,11 @@ class ROCmDocs:
 
         pkg = importlib_resources.files("rocm_docs")
         copy_from_package(pkg / "data", "data", ".")
+
+
+def setup(app: Sphinx):
+    """Set up rocm_docs_core as a Sphinx extension as well.
+
+    Args:
+        app (Sphinx): Sphinx application to access the API.
+    """

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -100,8 +100,8 @@ def format_toc(
         toc_path = Path(toc_path)
     if repo_path is None:
         repo_path = toc_path
-    input_name = "_toc.yml.in" if input_name is None else input_name
-    output_name = "_toc.yml" if output_name is None else output_name
+    input_name = "./.sphinx/_toc.yml.in" if input_name is None else input_name
+    output_name = "./.sphinx/_toc.yml" if output_name is None else output_name
     at_start = True
 
     url, branch, _ = get_branch(repo_path)

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -48,7 +48,10 @@ def get_branch(
         remote_url = repo.remotes.origin.url
         build_type = os.environ["READTHEDOCS_VERSION_TYPE"]
         if build_type in ("branch", "tag"):
-            return remote_url, os.environ["READTHEDOCS_VERSION"], True
+            url = re.sub(
+                        r"(?:.*://)?(.*\.com)[/:](.*)\.git", r"\1/\2", remote_url
+                    )
+            return url, os.environ["READTHEDOCS_VERSION"], True
         if build_type == "external":
             repo_fqn = re.sub(r".*\.com[/:](.*)\.git", r"\1", remote_url)
             print("Repository URL: " + repo_fqn)
@@ -62,7 +65,7 @@ def get_branch(
                     # Possibly a private repository that we're not
                     # authenticated for, fallback
                     url = re.sub(
-                        r".*://(.*\.com)[/:](.*)\.git", r"\1/\2", remote_url
+                        r"(?:.*://)?(.*\.com)[/:](.*)\.git", r"\1/\2", remote_url
                     )
                     return (
                         url,

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -1,11 +1,13 @@
 """Utilities for rocm-docs-core."""
+import functools
 import os
 import re
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 from pathlib import Path
 from git import Remote, RemoteReference
 from git.repo import Repo
-from github import Github
+import github
+from github.GithubException import UnknownObjectException
 
 
 def get_path_to_docs(
@@ -25,7 +27,10 @@ def get_path_to_docs(
     return os.path.relpath(str(conf_path), repo.working_dir)
 
 
-def get_branch(repo_path: Union[str, os.PathLike, None] = None):
+@functools.lru_cache
+def get_branch(
+    repo_path: Union[str, os.PathLike, None] = None,
+) -> Tuple[str, str, bool]:
     """Get the branch whose tip is checked out, even if detached."""
     git_url = re.compile(r"git@(\w+(?:\.\w+)+):(.*)\.git")
     if repo_path is None:
@@ -37,19 +42,33 @@ def get_branch(repo_path: Union[str, os.PathLike, None] = None):
     if os.environ.get("READTHEDOCS", ""):
         gh_token = os.environ.get("TOKEN", "")
         if gh_token:
-            gh_inst = Github(gh_token)
+            gh_inst = github.Github(gh_token)
         else:
-            gh_inst = Github()
+            gh_inst = github.Github()
         remote_url = repo.remotes.origin.url
         build_type = os.environ["READTHEDOCS_VERSION_TYPE"]
-        if build_type == "branch" or build_type == "tag":
-            return remote_url, os.environ["READTHEDOCS_VERSION"]
+        if build_type in ("branch", "tag"):
+            return remote_url, os.environ["READTHEDOCS_VERSION"], True
         if build_type == "external":
-            url = re.sub(r".*\.com[/:](.*)\.git", r"\1", remote_url)
-            print("Repository URL: " + url)
-            g_repo = gh_inst.get_repo(url)
-            pull = g_repo.get_pull(int(os.environ["READTHEDOCS_VERSION"]))
-            return pull.head.repo.html_url, pull.head.ref
+            repo_fqn = re.sub(r".*\.com[/:](.*)\.git", r"\1", remote_url)
+            print("Repository URL: " + repo_fqn)
+            try:
+                pull = gh_inst.get_repo(repo_fqn).get_pull(
+                    int(os.environ["READTHEDOCS_VERSION"])
+                )
+                return pull.head.repo.html_url, pull.head.ref, True
+            except UnknownObjectException as err:
+                if err.data["message"] == "Not Found":
+                    # Possibly a private repository that we're not
+                    # authenticated for, fallback
+                    url = re.sub(
+                        r".*://(.*\.com)[/:](.*)\.git", r"\1/\2", remote_url
+                    )
+                    return (
+                        url,
+                        "external-" + os.environ["READTHEDOCS_VERSION"],
+                        False,
+                    )
         # if build type is unknown try the usual strategy
     for branch in repo.branches:
         if branch.commit == repo.head.commit:
@@ -57,14 +76,14 @@ def get_branch(repo_path: Union[str, os.PathLike, None] = None):
             if tracking is not None:
                 remote_url = repo.remotes[tracking.remote_name].url
                 remote_url = git_url.sub(r"http://\1/\2", remote_url)
-                return remote_url, tracking.remote_head
+                return remote_url, tracking.remote_head, True
     for remote in repo.remotes:
         remote: Remote
         for ref in remote.refs:
             ref: RemoteReference
             if ref.commit == repo.head.commit:
                 remote_url = git_url.sub(r"http://\1/\2", remote.url)
-                return remote_url, ref.remote_head
+                return remote_url, ref.remote_head, True
     raise TypeError("Could not find the commit in the git repo.")
 
 
@@ -81,11 +100,11 @@ def format_toc(
         toc_path = Path(toc_path)
     if repo_path is None:
         repo_path = toc_path
-    input_name = "./.sphinx/_toc.yml.in" if input_name is None else input_name
-    output_name = "./.sphinx/_toc.yml" if output_name is None else output_name
+    input_name = "_toc.yml.in" if input_name is None else input_name
+    output_name = "_toc.yml" if output_name is None else output_name
     at_start = True
 
-    url, branch = get_branch(repo_path)
+    url, branch, _ = get_branch(repo_path)
     with open(toc_path / input_name, "r", encoding="utf-8") as toc_in:
         with open(toc_path / output_name, "w", encoding="utf-8") as toc_out:
             for line in toc_in.readlines():
@@ -93,7 +112,6 @@ def format_toc(
                     continue
                 at_start = False
                 toc_out.write(line.format(branch=branch, url=url))
-    return url, branch
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the repository being built is private and no token is provided, we cannot connect to GitHub to get pull request information, so pull request builds will fail. This PR disables the edit button when we cannot get sufficient information to enable it, and adds some placeholder information for formatting the table of contents.