### PR TITLE
Remove hover effect from cookie settings

### DIFF
--- a/src/rocm_docs/data/_static/custom.css
+++ b/src/rocm_docs/data/_static/custom.css
@@ -78,16 +78,4 @@ a#ot-sdk-btn {
     font-size: 12px !important;
     color:white !important;
     padding: 0 !important;
-    vertical-align: super;
-}
-
-a#ot-sdk-btn:hover {
-    font-family: -apple-system,BlinkMacSystemFont,Segoe UI,"Helvetica Neue",Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol !important;
-    font-size: 12px !important;
-    color: #ed1c24 !important;
-    text-decoration:none !important;
-}
-
-a#ot-sdk-btn:focus {
-    outline:none !important;
 }


### PR DESCRIPTION
Make the cookie settings align vertically with other footer links

Remove the red hover effect