### PR TITLE
Add fieldlist and replacements MyST extension

### DIFF
--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -202,7 +202,12 @@ class ROCmDocs:
             self.breathe_default_project = ""
 
         # MyST Configuration
-        self.myst_enable_extensions = ["colon_fence", "linkify"]
+        self.myst_enable_extensions = [
+            "colon_fence",
+            "linkify",
+            "fieldlist",
+            "replacements"
+        ]
         self.myst_heading_anchors = 3
 
         # Table of Contents Configuration


### PR DESCRIPTION
Enables two MyST extensions:
- [`replacements`](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#typography) converts `(tm) (c)` to `™ ©`.
- [`fieldlist`](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#field-lists) is more visually pleasing than using tables to document command arguments.