### PR TITLE
Improve error message if doxygen not found in PATH

### DIFF
--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -138,9 +138,15 @@ class ROCmDocs:
             raise FileNotFoundError(
                 f"Expected doxyfile {doxyfile} to exist and be readable."
             )
+
+        doxygen_exe = shutil.which("doxygen")
+        if doxygen_exe is None:
+            raise RuntimeError("'doxygen' command not found! Make sure that "
+                               "doxygen is installed and in the PATH")
+
         try:
-            subprocess.check_call(["doxygen", "--version"], cwd=doxygen_root)
-            subprocess.check_call(["doxygen", doxygen_file], cwd=doxygen_root)
+            subprocess.check_call([doxygen_exe, "--version"], cwd=doxygen_root)
+            subprocess.check_call([doxygen_exe, doxygen_file], cwd=doxygen_root)
         except subprocess.CalledProcessError as err:
             raise RuntimeError("Failed when running doxygen") from err
         try:


### PR DESCRIPTION
Look up doxygen in the path before trying to execute it using `shutil.which`.
Using full paths to executables [is recommended][1] anyways as it avoids differences in platform search behaviour.

[1]: https://docs.python.org/3/library/subprocess.html#subprocess.Popen