### PR TITLE
Separate bibtex requirement from rocm-docs-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "sphinx_external_toc==0.3.1",
   "sphinx-book-theme==1.0.0rc2",
   "myst_nb==0.17.1",
-  "myst-parser[linkify]==0.18.1"
+  "myst-parser[linkify]==0.18.1",
+  "sphinx-notfound-page==0.8.3" 
 ]
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ dependencies = [
   "sphinx_external_toc==0.3.1",
   "sphinx-book-theme==1.0.0rc2",
   "myst_nb==0.17.1",
-  "myst-parser[linkify]==0.18.1",
-  "sphinx-notfound-page==0.8.3",
-  "sphinxcontrib-bibtex==2.5.0",
+  "myst-parser[linkify]==0.18.1"
 ]
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -205,6 +205,7 @@ sphinx==4.3.1
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-notfound-page
 sphinx-book-theme==1.0.0rc2
     # via rocm-docs-core (pyproject.toml)
 sphinx-copybutton==0.5.1
@@ -212,6 +213,8 @@ sphinx-copybutton==0.5.1
 sphinx-design==0.3.0
     # via rocm-docs-core (pyproject.toml)
 sphinx-external-toc==0.3.1
+    # via rocm-docs-core (pyproject.toml)
+sphinx-notfound-page==0.8.3
     # via rocm-docs-core (pyproject.toml)
 sphinxcontrib-applehelp==1.0.4
     # via sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,11 +46,9 @@ docutils==0.16
     # via
     #   breathe
     #   myst-parser
-    #   pybtex-docutils
     #   pydata-sphinx-theme
     #   rocm-docs-core (pyproject.toml)
     #   sphinx
-    #   sphinxcontrib-bibtex
 executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.3
@@ -96,8 +94,6 @@ jupyter-core==5.2.0
     #   ipykernel
     #   jupyter-client
     #   nbformat
-latexcodec==2.0.1
-    # via pybtex
 linkify-it-py==1.0.3
     # via myst-parser
 markdown-it-py==2.2.0
@@ -154,12 +150,6 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pybtex==0.24.0
-    # via
-    #   pybtex-docutils
-    #   sphinxcontrib-bibtex
-pybtex-docutils==1.0.2
-    # via sphinxcontrib-bibtex
 pycparser==2.21
     # via cffi
 pydata-sphinx-theme==0.13.1
@@ -185,7 +175,6 @@ pyyaml==6.0
     #   jupyter-cache
     #   myst-nb
     #   myst-parser
-    #   pybtex
     #   sphinx-external-toc
 pyzmq==25.0.0
     # via
@@ -198,8 +187,6 @@ requests==2.28.2
 six==1.16.0
     # via
     #   asttokens
-    #   latexcodec
-    #   pybtex
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
@@ -218,8 +205,6 @@ sphinx==4.3.1
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
-    #   sphinx-notfound-page
-    #   sphinxcontrib-bibtex
 sphinx-book-theme==1.0.0rc2
     # via rocm-docs-core (pyproject.toml)
 sphinx-copybutton==0.5.1
@@ -228,12 +213,8 @@ sphinx-design==0.3.0
     # via rocm-docs-core (pyproject.toml)
 sphinx-external-toc==0.3.1
     # via rocm-docs-core (pyproject.toml)
-sphinx-notfound-page==0.8.3
-    # via rocm-docs-core (pyproject.toml)
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
-sphinxcontrib-bibtex==2.5.0
-    # via rocm-docs-core (pyproject.toml)
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -196,7 +196,7 @@ class ROCmDocs:
         ]
 
         if self._ran_doxygen:
-            self.extensions += ["sphinx.ext.mathjax", "breathe", "sphinxcontrib.bibtex"]
+            self.extensions += ["sphinx.ext.mathjax", "breathe"]
             self.breathe_projects = {
                 self._project_name: str(self._doxygen_path)
             }


### PR DESCRIPTION
Since [CK](https://github.com/ROCmSoftwarePlatform/composable_kernel/) is the only repo that uses this extension and it requires a custom config, it doesn't seem worthwhile to add it as a dependency to all repos that use rocm-docs-core.

Successful test build using hipBLAS: https://readthedocs.com/projects/advanced-micro-devices-hipblas/builds/1373708/