### PR TITLE
API reference styling

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 /_build
+/_doxygen
 /_images
 /_static
 /_templates

--- a/docs/demo/doxygen/Doxyfile
+++ b/docs/demo/doxygen/Doxyfile
@@ -1331,7 +1331,7 @@ HTML_FILE_EXTENSION    = .html
 # of the possible markers and block names see the documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_HEADER            =
+HTML_HEADER            = ../../_doxygen/header.html
 
 # The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
 # generated HTML page. If the tag is left blank doxygen will generate a standard
@@ -1341,7 +1341,7 @@ HTML_HEADER            =
 # that doxygen normally uses.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_FOOTER            =
+HTML_FOOTER            = ../../_doxygen/footer.html
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading style
 # sheet that is used by each HTML page. It can be used to fine-tune the look of
@@ -1353,7 +1353,7 @@ HTML_FOOTER            =
 # obsolete.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_STYLESHEET        =
+HTML_STYLESHEET        = ../../_doxygen/stylesheet.css
 
 # The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
 # cascading style sheets that are included after the standard style sheets
@@ -1371,7 +1371,7 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  =
+HTML_EXTRA_STYLESHEET  = ../../_doxygen/extra_stylesheet.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -149,6 +149,11 @@ class ROCmDocs:
             raise RuntimeError("'doxygen' command not found! Make sure that "
                                "doxygen is installed and in the PATH")
 
+        
+        # Running doxygen requires that the files are already copied because 
+        # the Doxyfile references files distributed with rocm-docs-core
+        # (e.g. stylesheets)
+        self.copy_files()
         try:
             subprocess.check_call([doxygen_exe, "--version"], cwd=doxygen_root)
             subprocess.check_call([doxygen_exe, doxygen_file], cwd=doxygen_root)

--- a/src/rocm_docs/data/_doxygen/extra_stylesheet.css
+++ b/src/rocm_docs/data/_doxygen/extra_stylesheet.css
@@ -1,0 +1,2498 @@
+/**
+
+Doxygen Awesome
+https://github.com/jothepro/doxygen-awesome-css
+
+MIT License
+
+Copyright (c) 2021 - 2023 jothepro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Modified to work with doxysphinx and the PyData Sphinx theme
+
+Modifications Copyright (c) 2019, Advanced Micro Devices, Inc. All rights reserved.
+*/
+
+html {
+    /* primary theme color. This will affect the entire websites color scheme: links, arrows, labels, ... */
+    --primary-color: #1779c4;
+    --primary-dark-color: #335c80;
+    --primary-light-color: #70b1e9;
+
+    /* page base colors */
+    --page-background-color: transparent;
+    --page-foreground-color: #2f4153;
+    --page-secondary-foreground-color: #6f7e8e;
+
+    /* color for all separators on the website: hr, borders, ... */
+    --separator-color: #dedede;
+
+    /* border radius for all rounded components. Will affect many components, like dropdowns, memitems, codeblocks, ... */
+    --border-radius-large: 8px;
+    --border-radius-small: 4px;
+    --border-radius-medium: 6px;
+
+    /* default spacings. Most components reference these values for spacing, to provide uniform spacing on the page. */
+    --spacing-small: 5px;
+    --spacing-medium: 10px;
+    --spacing-large: 16px;
+
+    /* default box shadow used for raising an element above the normal content. Used in dropdowns, search result, ... */
+    --box-shadow: 0 2px 8px 0 rgba(0,0,0,.075);
+
+    --odd-color: rgba(0,0,0,.028);
+
+    /* font-families. will affect all text on the website
+     * font-family: the normal font for text, headlines, menus
+     * font-family-monospace: used for preformatted text in memtitle, code, fragments
+     */
+    --font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Fira Sans,Droid Sans,Helvetica Neue,sans-serif;
+    --font-family-monospace: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+
+    /* font sizes */
+    --page-font-size: 15.6px;
+    --navigation-font-size: 14.4px;
+    --toc-font-size: 13.4px;
+    --code-font-size: 14px; /* affects code, fragment */
+    --title-font-size: 22px;
+
+    /* content text properties. These only affect the page content, not the navigation or any other ui elements */
+    --content-line-height: 27px;
+    /* The content is centered and constraint in it's width. To make the content fill the whole page, set the variable to auto.*/
+    --content-maxwidth: auto;
+    --table-line-height: 24px;
+    --toc-sticky-top: var(--spacing-medium);
+    --toc-width: 200px;
+    --toc-max-height: calc(100vh - 2 * var(--spacing-medium) - 85px);
+
+    /* colors for various content boxes: @warning, @note, @deprecated @bug */
+    --warning-color: #f8d1cc;
+    --warning-color-dark: #b61825;
+    --warning-color-darker: #75070f;
+    --note-color: #faf3d8;
+    --note-color-dark: #f3a600;
+    --note-color-darker: #5f4204;
+    --todo-color: #e4f3ff;
+    --todo-color-dark: #1879C4;
+    --todo-color-darker: #274a5c;
+    --deprecated-color: #ecf0f3;
+    --deprecated-color-dark: #5b6269;
+    --deprecated-color-darker: #43454a;
+    --bug-color: #e4dafd;
+    --bug-color-dark: #5b2bdd;
+    --bug-color-darker: #2a0d72;
+    --invariant-color: #d8f1e3;
+    --invariant-color-dark: #44b86f;
+    --invariant-color-darker: #265532;
+
+    /* blockquote colors */
+    --blockquote-background: #f8f9fa;
+    --blockquote-foreground: #636568;
+
+    /* table colors */
+    --tablehead-background: #f1f1f1;
+    --tablehead-foreground: var(--page-foreground-color);
+
+    /* menu-display: block | none
+     * Visibility of the top navigation on screens >= 768px. On smaller screen the menu is always visible.
+     * `GENERATE_TREEVIEW` MUST be enabled!
+     */
+    --menu-display: block;
+
+    --menu-focus-foreground: var(--page-background-color);
+    --menu-focus-background: var(--primary-color);
+    --menu-selected-background: rgba(0,0,0,.05);
+
+
+    --header-background: var(--page-background-color);
+    --header-foreground: var(--page-foreground-color);
+
+    /* searchbar colors */
+    --searchbar-background: var(--side-nav-background);
+    --searchbar-foreground: var(--page-foreground-color);
+
+    /* searchbar size
+     * (`searchbar-width` is only applied on screens >= 768px.
+     * on smaller screens the searchbar will always fill the entire screen width) */
+    --searchbar-height: 33px;
+    --searchbar-width: 210px;
+    --searchbar-border-radius: var(--searchbar-height);
+
+    /* code block colors */
+    --code-background: #f5f5f5;
+    --code-foreground: var(--page-foreground-color);
+
+    /* fragment colors */
+    --fragment-background: #F8F9FA;
+    --fragment-foreground: #37474F;
+    --fragment-keyword: #bb6bb2;
+    --fragment-keywordtype: #8258b3;
+    --fragment-keywordflow: #d67c3b;
+    --fragment-token: #438a59;
+    --fragment-comment: #969696;
+    --fragment-link: #5383d6;
+    --fragment-preprocessor: #46aaa5;
+    --fragment-linenumber-color: #797979;
+    --fragment-linenumber-background: #f4f4f5;
+    --fragment-linenumber-border: #e3e5e7;
+    --fragment-lineheight: 20px;
+
+    /* sidebar navigation (treeview) colors */
+    --side-nav-background: #fbfbfb;
+    --side-nav-foreground: var(--page-foreground-color);
+    --side-nav-arrow-opacity: 0;
+    --side-nav-arrow-hover-opacity: 0.9;
+
+    --toc-background: var(--side-nav-background);
+    --toc-foreground: var(--side-nav-foreground);
+
+    /* height of an item in any tree / collapsible table */
+    --tree-item-height: 30px;
+
+    --memname-font-size: var(--code-font-size);
+    --memtitle-font-size: 18px;
+
+    --webkit-scrollbar-size: 7px;
+    --webkit-scrollbar-padding: 4px;
+    --webkit-scrollbar-color: var(--separator-color);
+}
+
+@media screen and (max-width: 767px) {
+    html {
+        --page-font-size: 16px;
+        --navigation-font-size: 16px;
+        --toc-font-size: 15px;
+        --code-font-size: 15px; /* affects code, fragment */
+        --title-font-size: 22px;
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) {
+        color-scheme: dark;
+
+        --primary-color: #1982d2;
+        --primary-dark-color: #86a9c4;
+        --primary-light-color: #4779ac;
+
+        --box-shadow: 0 2px 8px 0 rgba(0,0,0,.35);
+
+        --odd-color: rgba(100,100,100,.06);
+
+        --menu-selected-background: rgba(0,0,0,.4);
+
+        --page-background-color: transparent;
+        --page-foreground-color: #d2dbde;
+        --page-secondary-foreground-color: #859399;
+        --separator-color: #38393b;
+        --side-nav-background: #252628;
+
+        --code-background: #2a2c2f;
+
+        --tablehead-background: #2a2c2f;
+    
+        --blockquote-background: #222325;
+        --blockquote-foreground: #7e8c92;
+
+        --warning-color: #2e1917;
+        --warning-color-dark: #ad2617;
+        --warning-color-darker: #f5b1aa;
+        --note-color: #3b2e04;
+        --note-color-dark: #f1b602;
+        --note-color-darker: #ceb670;
+        --todo-color: #163750;
+        --todo-color-dark: #1982D2;
+        --todo-color-darker: #dcf0fa;
+        --deprecated-color: #2e323b;
+        --deprecated-color-dark: #738396;
+        --deprecated-color-darker: #abb0bd;
+        --bug-color: #2a2536;
+        --bug-color-dark: #7661b3;
+        --bug-color-darker: #ae9ed6;
+        --invariant-color: #303a35;
+        --invariant-color-dark: #76ce96;
+        --invariant-color-darker: #cceed5;
+
+        --fragment-background: #282c34;
+        --fragment-foreground: #dbe4eb;
+        --fragment-keyword: #cc99cd;
+        --fragment-keywordtype: #ab99cd;
+        --fragment-keywordflow: #e08000;
+        --fragment-token: #7ec699;
+        --fragment-comment: #999999;
+        --fragment-link: #98c0e3;
+        --fragment-preprocessor: #65cabe;
+        --fragment-linenumber-color: #cccccc;
+        --fragment-linenumber-background: #35393c;
+        --fragment-linenumber-border: #1f1f1f;
+    }
+}
+
+/* dark mode variables are defined twice, to support both the dark-mode without and with doxygen-awesome-darkmode-toggle.js */
+html[data-theme=dark] {
+    color-scheme: dark;
+
+    --primary-color: #1982d2;
+    --primary-dark-color: #86a9c4;
+    --primary-light-color: #4779ac;
+
+    --box-shadow: 0 2px 8px 0 rgba(0,0,0,.30);
+
+    --odd-color: rgba(100,100,100,.12);
+
+    --menu-selected-background: rgba(0,0,0,.4);
+
+    --page-background-color: transparent;
+    --page-foreground-color: #d2dbde;
+    --page-secondary-foreground-color: #859399;
+    --separator-color: #38393b;
+    --side-nav-background: #252628;
+
+    --code-background: #2a2c2f;
+
+    --tablehead-background: #2a2c2f;
+
+    --blockquote-background: #222325;
+    --blockquote-foreground: #7e8c92;
+
+    --warning-color: #2e1917;
+    --warning-color-dark: #ad2617;
+    --warning-color-darker: #f5b1aa;
+    --note-color: #3b2e04;
+    --note-color-dark: #f1b602;
+    --note-color-darker: #ceb670;
+    --todo-color: #163750;
+    --todo-color-dark: #1982D2;
+    --todo-color-darker: #dcf0fa;
+    --deprecated-color: #2e323b;
+    --deprecated-color-dark: #738396;
+    --deprecated-color-darker: #abb0bd;
+    --bug-color: #2a2536;
+    --bug-color-dark: #7661b3;
+    --bug-color-darker: #ae9ed6;
+    --invariant-color: #303a35;
+    --invariant-color-dark: #76ce96;
+    --invariant-color-darker: #cceed5;
+
+    --fragment-background: #282c34;
+    --fragment-foreground: #dbe4eb;
+    --fragment-keyword: #cc99cd;
+    --fragment-keywordtype: #ab99cd;
+    --fragment-keywordflow: #e08000;
+    --fragment-token: #7ec699;
+    --fragment-comment: #999999;
+    --fragment-link: #98c0e3;
+    --fragment-preprocessor: #65cabe;
+    --fragment-linenumber-color: #cccccc;
+    --fragment-linenumber-background: #35393c;
+    --fragment-linenumber-border: #1f1f1f;
+}
+
+.doxygen-content {
+    color: var(--page-foreground-color);
+    background-color: var(--page-background-color);
+    font-size: var(--page-font-size);
+}
+
+.doxygen-content, .doxygen-content table, .doxygen-content div, .doxygen-content p, .doxygen-content dl, .doxygen-content #nav-tree .label, .doxygen-content .title,
+.doxygen-content .sm-dox a, .doxygen-content .sm-dox a:hover, .doxygen-content .sm-dox a:focus, .doxygen-content #projectname,
+.doxygen-content .SelectItem, .doxygen-content #MSearchField, .doxygen-content .navpath li.navelem a,
+.doxygen-content .navpath li.navelem a:hover, .doxygen-content p.reference, .doxygen-content p.definition {
+    font-family: var(--font-family);
+}
+
+.doxygen-content h1, .doxygen-content h2, .doxygen-content h3, .doxygen-content h4, .doxygen-content h5 {
+    margin-top: .9em;
+    font-weight: 600;
+    line-height: initial;
+}
+
+.doxygen-content p, .doxygen-content div, .doxygen-content table, .doxygen-content dl, .doxygen-content p.reference, .doxygen-content p.definition {
+    font-size: var(--page-font-size);
+}
+
+.doxygen-content p.reference, .doxygen-content p.definition {
+    color: var(--page-secondary-foreground-color);
+}
+
+.doxygen-content a:link, .doxygen-content a:visited, .doxygen-content a:hover, .doxygen-content a:focus, .doxygen-content a:active {
+    color: var(--primary-color) !important;
+    font-weight: 500;
+}
+
+.doxygen-content a.anchor {
+    scroll-margin-top: var(--spacing-large);
+    display: block;
+}
+
+/*
+ Title and top navigation
+ */
+
+.doxygen-content #top {
+    background: var(--header-background);
+    border-bottom: 1px solid var(--separator-color);
+}
+
+@media screen and (min-width: 768px) {
+    .doxygen-content #top {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+    }
+}
+
+.doxygen-content #main-nav {
+    flex-grow: 5;
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+.doxygen-content #titlearea {
+    width: auto;
+    padding: var(--spacing-medium) var(--spacing-large);
+    background: none;
+    color: var(--header-foreground);
+    border-bottom: none;
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content #titlearea {
+        padding-bottom: var(--spacing-small);
+    }
+}
+
+.doxygen-content #titlearea table tbody tr {
+    height: auto !important;
+}
+
+.doxygen-content #projectname {
+    font-size: var(--title-font-size);
+    font-weight: 600;
+}
+
+.doxygen-content #projectnumber {
+    font-family: inherit;
+    font-size: 60%;
+}
+
+.doxygen-content #projectbrief {
+    font-family: inherit;
+    font-size: 80%;
+}
+
+.doxygen-content #projectlogo {
+    vertical-align: middle;
+}
+
+.doxygen-content #projectlogo img {
+    max-height: calc(var(--title-font-size) * 2);
+    margin-right: var(--spacing-small);
+}
+
+.doxygen-content .sm-dox, .doxygen-content .tabs, .doxygen-content .tabs2, .doxygen-content .tabs3 {
+    background: none;
+    padding: 0;
+}
+
+.doxygen-content .tabs, .doxygen-content .tabs2, .doxygen-content .tabs3 {
+    border-bottom: 1px solid var(--separator-color);
+    margin-bottom: -1px;
+}
+
+.doxygen-content .main-menu-btn-icon, .doxygen-content .main-menu-btn-icon:before, .doxygen-content .main-menu-btn-icon:after {
+    background: var(--page-secondary-foreground-color);
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content .sm-dox a span.sub-arrow {
+        background: var(--code-background);
+    }
+
+    .doxygen-content #main-menu a.has-submenu span.sub-arrow {
+        color: var(--page-secondary-foreground-color);
+        border-radius: var(--border-radius-medium);
+    }
+
+    .doxygen-content #main-menu a.has-submenu:hover span.sub-arrow {
+        color: var(--page-foreground-color);
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .doxygen-content .sm-dox li, .doxygen-content .tablist li {
+        display: var(--menu-display);
+    }
+
+    .doxygen-content .sm-dox a span.sub-arrow {
+        border-color: var(--header-foreground) transparent transparent transparent;
+    }
+
+    .doxygen-content .sm-dox a:hover span.sub-arrow {
+        border-color: var(--menu-focus-foreground) transparent transparent transparent;
+    }
+
+    .doxygen-content .sm-dox ul a span.sub-arrow {
+        border-color: transparent transparent transparent var(--page-foreground-color);
+    }
+
+    .doxygen-content .sm-dox ul a:hover span.sub-arrow {
+        border-color: transparent transparent transparent var(--menu-focus-foreground);
+    }
+}
+
+.doxygen-content .sm-dox ul {
+    background: var(--page-background-color);
+    box-shadow: var(--box-shadow);
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium) !important;
+    padding: var(--spacing-small);
+    animation: ease-out 150ms slideInMenu;
+}
+
+@keyframes slideInMenu {
+    from {
+        opacity: 0;
+        transform: translate(0px, -2px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate(0px, 0px);
+    }
+}
+
+.doxygen-content .sm-dox ul a {
+    color: var(--page-foreground-color) !important;
+    background: var(--page-background-color);
+    font-size: var(--navigation-font-size);
+}
+
+.doxygen-content .sm-dox>li>ul:after {
+    border-bottom-color: var(--page-background-color) !important;
+}
+
+.doxygen-content .sm-dox>li>ul:before {
+    border-bottom-color: var(--separator-color) !important;
+}
+
+.doxygen-content .sm-dox ul a:hover, .doxygen-content .sm-dox ul a:active, .doxygen-content .sm-dox ul a:focus {
+    font-size: var(--navigation-font-size) !important;
+    color: var(--menu-focus-foreground) !important;
+    text-shadow: none;
+    background-color: var(--menu-focus-background);
+    border-radius: var(--border-radius-small) !important;
+}
+
+.doxygen-content .sm-dox a, .doxygen-content .sm-dox a:focus, .doxygen-content .tablist li, .doxygen-content .tablist li a, .doxygen-content .tablist li.current a {
+    text-shadow: none;
+    background: transparent;
+    background-image: none !important;
+    color: var(--header-foreground) !important;
+    font-weight: normal;
+    font-size: var(--navigation-font-size);
+    border-radius: var(--border-radius-small) !important;
+}
+
+.doxygen-content .sm-dox a:focus {
+    outline: auto;
+}
+
+.doxygen-content .sm-dox a:hover, .doxygen-content .sm-dox a:active, .doxygen-content .tablist li a:hover {
+    text-shadow: none;
+    font-weight: normal;
+    background: var(--menu-focus-background);
+    color: var(--menu-focus-foreground) !important;
+    border-radius: var(--border-radius-small) !important;
+    font-size: var(--navigation-font-size);
+}
+
+.doxygen-content .tablist li.current {
+    border-radius: var(--border-radius-small);
+    background: var(--menu-selected-background);
+}
+
+.doxygen-content .tablist li {
+    margin: var(--spacing-small) 0 var(--spacing-small) var(--spacing-small);
+}
+
+.doxygen-content .tablist a {
+    padding: 0 var(--spacing-large);
+}
+
+
+/*
+ Search box
+ */
+
+.doxygen-content #MSearchBox {
+    height: var(--searchbar-height);
+    background: var(--searchbar-background);
+    border-radius: var(--searchbar-border-radius);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+    width: var(--searchbar-width);
+    position: relative;
+    box-shadow: none;
+    display: block;
+    margin-top: 0;
+}
+
+/* until Doxygen 1.9.4 */
+.doxygen-content .left img#MSearchSelect {
+    left: 0;
+    user-select: none;
+    padding-left: 8px;
+}
+
+/* Doxygen 1.9.5 */
+.doxygen-content .left span#MSearchSelect {
+    left: 0;
+    user-select: none;
+    margin-left: 8px;
+    padding: 0;
+}
+
+.doxygen-content .left #MSearchSelect[src$=".png"] {
+    padding-left: 0
+}
+
+.doxygen-content .SelectionMark {
+    user-select: none;
+}
+
+.doxygen-content .tabs .left #MSearchSelect {
+    padding-left: 0;
+}
+
+.doxygen-content .tabs #MSearchBox {
+    position: absolute;
+    right: var(--spacing-medium);
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content .tabs #MSearchBox {
+        position: relative;
+        right: 0;
+        margin-left: var(--spacing-medium);
+        margin-top: 0;
+    }
+}
+
+.doxygen-content #MSearchSelectWindow, .doxygen-content #MSearchResultsWindow {
+    z-index: 9999;
+}
+
+.doxygen-content #MSearchBox.MSearchBoxActive {
+    border-color: var(--primary-color);
+    box-shadow: inset 0 0 0 1px var(--primary-color);
+}
+
+.doxygen-content #main-menu > li:last-child {
+    margin-right: 0;
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content #main-menu > li:last-child {
+        height: 50px;
+    }
+}
+
+.doxygen-content #MSearchField {
+    font-size: var(--navigation-font-size);
+    height: calc(var(--searchbar-height) - 2px);
+    background: transparent;
+    width: calc(var(--searchbar-width) - 64px);
+}
+
+.doxygen-content .MSearchBoxActive #MSearchField {
+    color: var(--searchbar-foreground);
+}
+
+.doxygen-content #MSearchSelect {
+    top: calc(calc(var(--searchbar-height) / 2) - 11px);
+}
+
+.doxygen-content #MSearchBox span.left, .doxygen-content #MSearchBox span.right {
+    background: none;
+    background-image: none;
+}
+
+.doxygen-content #MSearchBox span.right {
+    padding-top: calc(calc(var(--searchbar-height) / 2) - 12px);
+    position: absolute;
+    right: var(--spacing-small);
+}
+
+.doxygen-content .tabs #MSearchBox span.right {
+    top: calc(calc(var(--searchbar-height) / 2) - 12px);
+}
+
+@keyframes slideInSearchResults {
+    from {
+        opacity: 0;
+        transform: translate(0, 15px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translate(0, 20px);
+    }
+}
+
+.doxygen-content #MSearchResultsWindow {
+    left: auto !important;
+    right: var(--spacing-medium);
+    border-radius: var(--border-radius-large);
+    border: 1px solid var(--separator-color);
+    transform: translate(0, 20px);
+    box-shadow: var(--box-shadow);
+    animation: ease-out 280ms slideInSearchResults;
+    background: var(--page-background-color);
+}
+
+.doxygen-content iframe#MSearchResults {
+    margin: 4px;
+}
+
+.doxygen-content iframe {
+    color-scheme: normal;
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) .doxygen-content iframe#MSearchResults {
+        filter: invert() hue-rotate(180deg);
+    }
+}
+
+html[data-theme=dark] .doxygen-content iframe#MSearchResults {
+    filter: invert() hue-rotate(180deg);
+}
+
+.doxygen-content #MSearchResults .SRPage {
+    background-color: transparent;
+}
+
+.doxygen-content #MSearchResults .SRPage .SREntry {
+    font-size: 10pt;
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+.doxygen-content #MSearchSelectWindow {
+    border: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-medium);
+    box-shadow: var(--box-shadow);
+    background: var(--page-background-color);
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+}
+
+.doxygen-content #MSearchSelectWindow a.SelectItem {
+    font-size: var(--navigation-font-size);
+    line-height: var(--content-line-height);
+    margin: 0 var(--spacing-small);
+    border-radius: var(--border-radius-small);
+    color: var(--page-foreground-color) !important;
+    font-weight: normal;
+}
+
+.doxygen-content #MSearchSelectWindow a.SelectItem:hover {
+    background: var(--menu-focus-background);
+    color: var(--menu-focus-foreground) !important;
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content #MSearchBox {
+        margin-top: var(--spacing-medium);
+        margin-bottom: var(--spacing-medium);
+        width: calc(100vw - 30px);
+    }
+
+    .doxygen-content #main-menu > li:last-child {
+        float: none !important;
+    }
+
+    .doxygen-content #MSearchField {
+        width: calc(100vw - 110px);
+    }
+
+    @keyframes slideInSearchResultsMobile {
+        from {
+            opacity: 0;
+            transform: translate(0, 15px);
+        }
+
+        to {
+            opacity: 1;
+            transform: translate(0, 20px);
+        }
+    }
+
+    .doxygen-content #MSearchResultsWindow {
+        left: var(--spacing-medium) !important;
+        right: var(--spacing-medium);
+        overflow: auto;
+        transform: translate(0, 20px);
+        animation: ease-out 280ms slideInSearchResultsMobile;
+        width: auto !important;
+    }
+
+    /*
+     * Overwrites for fixing the searchbox on mobile in doxygen 1.9.2
+     */
+    .doxygen-content label.main-menu-btn ~ #searchBoxPos1 {
+        top: 3px !important;
+        right: 6px !important;
+        left: 45px;
+        display: flex;
+    }
+
+    .doxygen-content label.main-menu-btn ~ #searchBoxPos1 > #MSearchBox {
+        margin-top: 0;
+        margin-bottom: 0;
+        flex-grow: 2;
+        float: left;
+    }
+}
+
+/*
+ Tree view
+ */
+
+.doxygen-content #side-nav {
+    padding: 0 !important;
+    background: var(--side-nav-background);
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content #side-nav {
+        display: none;
+    }
+
+    .doxygen-content #doc-content {
+        margin-left: 0 !important;
+    }
+}
+
+.doxygen-content #nav-tree {
+    background: transparent;
+    margin-right: 1px;
+}
+
+.doxygen-content #nav-tree .label {
+    font-size: var(--navigation-font-size);
+}
+
+.doxygen-content #nav-tree .item {
+    height: var(--tree-item-height);
+    line-height: var(--tree-item-height);
+}
+
+.doxygen-content #nav-sync {
+    bottom: 12px;
+    right: 12px;
+    top: auto !important;
+    user-select: none;
+}
+
+.doxygen-content #nav-tree .selected {
+    text-shadow: none;
+    background-image: none;
+    background-color: transparent;
+    position: relative;
+}
+
+.doxygen-content #nav-tree .selected::after {
+    content: "";
+    position: absolute;
+    top: 1px;
+    bottom: 1px;
+    left: 0;
+    width: 4px;
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+    background: var(--primary-color);
+}
+
+
+.doxygen-content #nav-tree a {
+    color: var(--side-nav-foreground) !important;
+    font-weight: normal;
+}
+
+.doxygen-content #nav-tree a:focus {
+    outline-style: auto;
+}
+
+.doxygen-content #nav-tree .arrow {
+    opacity: var(--side-nav-arrow-opacity);
+}
+
+.doxygen-content .arrow {
+    color: inherit;
+    cursor: pointer;
+    font-size: 45%;
+    vertical-align: middle;
+    margin-right: 2px;
+    font-family: serif;
+    height: auto;
+    text-align: right;
+}
+
+.doxygen-content #nav-tree div.item:hover .arrow, .doxygen-content #nav-tree a:focus .arrow {
+    opacity: var(--side-nav-arrow-hover-opacity);
+}
+
+.doxygen-content #nav-tree .selected a {
+    color: var(--primary-color) !important;
+    font-weight: bolder;
+    font-weight: 600;
+}
+
+.doxygen-content .ui-resizable-e {
+    background: var(--separator-color);
+    width: 1px;
+}
+
+/*
+ Contents
+ */
+
+.doxygen-content div.header {
+    border-bottom: 1px solid var(--separator-color);
+    background-color: var(--page-background-color);
+    background-image: none;
+}
+
+@media screen and (min-width: 1000px) {
+    .doxygen-content #doc-content > div > div.contents,
+    .doxygen-content .PageDoc > div.contents {
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: nowrap;
+        align-items: flex-start;
+    }
+    
+    .doxygen-content div.contents .textblock {
+        min-width: 200px;
+        flex-grow: 1;
+    }
+}
+
+.doxygen-content div.contents, .doxygen-content div.header .title, .doxygen-content div.header .summary {
+    max-width: var(--content-maxwidth);
+}
+
+.doxygen-content div.contents, .doxygen-content div.header .title  {
+    line-height: initial;
+    margin: calc(var(--spacing-medium) + .2em) auto var(--spacing-medium) auto;
+}
+
+.doxygen-content div.header .summary {
+    margin: var(--spacing-medium) auto 0 auto;
+}
+
+.doxygen-content div.headertitle {
+    padding: 0;
+}
+
+.doxygen-content div.header .title {
+    font-weight: 600;
+    font-size: 225%;
+    padding: var(--spacing-medium) var(--spacing-large);
+    word-break: break-word;
+}
+
+.doxygen-content div.header .summary {
+    width: auto;
+    display: block;
+    float: none;
+    padding: 0 var(--spacing-large);
+}
+
+.doxygen-content td.memSeparator {
+    border-color: var(--separator-color);
+}
+
+.doxygen-content span.mlabel {
+    background: var(--primary-color);
+    border: none;
+    padding: 4px 9px;
+    border-radius: 12px;
+    margin-right: var(--spacing-medium);
+}
+
+.doxygen-content span.mlabel:last-of-type {
+    margin-right: 2px;
+}
+
+.doxygen-content div.contents {
+    padding: 0 var(--spacing-large);
+}
+
+.doxygen-content div.contents p, .doxygen-content div.contents li {
+    line-height: var(--content-line-height);
+}
+
+.doxygen-content div.contents div.dyncontent {
+    margin: var(--spacing-medium) 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) .doxygen-content div.contents div.dyncontent img,
+    html:not([data-theme=light]) .doxygen-content div.contents center img,
+    html:not([data-theme=light]) .doxygen-content div.contents > table img,
+    html:not([data-theme=light]) .doxygen-content div.contents div.dyncontent iframe,
+    html:not([data-theme=light]) .doxygen-content div.contents center iframe,
+    html:not([data-theme=light]) .doxygen-content div.contents table iframe,
+    html:not([data-theme=light]) .doxygen-content div.contents .dotgraph iframe {
+        filter: brightness(89%) hue-rotate(180deg) invert();
+    }
+}
+
+html[data-theme=dark] .doxygen-content div.contents div.dyncontent img,
+html[data-theme=dark] .doxygen-content div.contents center img,
+html[data-theme=dark] .doxygen-content div.contents > table img,
+html[data-theme=dark] .doxygen-content div.contents div.dyncontent iframe,
+html[data-theme=dark] .doxygen-content div.contents center iframe,
+html[data-theme=dark] .doxygen-content div.contents table iframe,
+html[data-theme=dark] .doxygen-content div.contents .dotgraph iframe
+ {
+    filter: brightness(89%) hue-rotate(180deg) invert();
+}
+
+.doxygen-content h2.groupheader {
+    border-bottom: 0px;
+    color: var(--page-foreground-color);
+    border-bottom: 1px solid var(--separator-color);
+}
+
+.doxygen-content blockquote {
+    margin: 0 var(--spacing-medium) 0 var(--spacing-medium);
+    padding: var(--spacing-small) var(--spacing-large);
+    background: var(--blockquote-background);
+    color: var(--blockquote-foreground);
+    border-left: 0;
+    overflow: visible;
+    border-radius: var(--border-radius-medium);
+    overflow: visible;
+    position: relative;
+}
+
+.doxygen-content blockquote::before, .doxygen-content blockquote::after {
+    font-weight: bold;
+    font-family: serif;
+    font-size: 360%;
+    opacity: .15;
+    position: absolute;
+}
+
+.doxygen-content blockquote::before {
+    content: "“";
+    left: -10px;
+    top: 4px;
+}
+
+.doxygen-content blockquote::after {
+    content: "”";
+    right: -8px;
+    bottom: -25px;
+}
+
+.doxygen-content blockquote p {
+    margin: var(--spacing-small) 0 var(--spacing-medium) 0;
+}
+.doxygen-content .paramname {
+    font-weight: 600;
+    color: var(--primary-dark-color);
+}
+
+.doxygen-content .paramname > code {
+    border: 0;
+}
+
+.doxygen-content table.params .paramname {
+    font-weight: 600;
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+    padding-right: var(--spacing-small);
+    line-height: var(--table-line-height);
+}
+
+.doxygen-content h1.glow, .doxygen-content h2.glow, .doxygen-content h3.glow, .doxygen-content h4.glow, .doxygen-content h5.glow, .doxygen-content h6.glow {
+    text-shadow: 0 0 15px var(--primary-light-color);
+}
+
+.doxygen-content .alphachar a {
+    color: var(--page-foreground-color);
+}
+
+.doxygen-content .dotgraph {
+    max-width: 100%;
+    overflow-x: scroll;
+}
+
+.doxygen-content .dotgraph .caption {
+    position: sticky;
+    left: 0;
+}
+
+/* Wrap Graphviz graphs with the `interactive_dotgraph` class if `INTERACTIVE_SVG = YES` */
+.doxygen-content .interactive_dotgraph .dotgraph iframe {
+    max-width: 100%;
+}
+
+/*
+ Table of Contents
+ */
+
+.doxygen-content div.contents .toc {
+    max-height: var(--toc-max-height);
+    min-width: var(--toc-width);
+    border: 0;
+    border-left: 1px solid var(--separator-color);
+    border-radius: 0;
+    background-color: transparent;
+    box-shadow: none;
+    position: sticky;
+    top: var(--toc-sticky-top);
+    padding: 0 var(--spacing-large);
+    margin: var(--spacing-small) 0 var(--spacing-large) var(--spacing-large);
+}
+
+.doxygen-content div.toc h3 {
+    color: var(--toc-foreground);
+    font-size: var(--navigation-font-size);
+    margin: var(--spacing-large) 0 var(--spacing-medium) 0;
+}
+
+.doxygen-content div.toc li {
+    padding: 0;
+    background: none;
+    line-height: var(--toc-font-size);
+    margin: var(--toc-font-size) 0 0 0;
+}
+
+.doxygen-content div.toc li::before {
+    display: none;
+}
+
+.doxygen-content div.toc ul {
+    margin-top: 0
+}
+
+.doxygen-content div.toc li a {
+    font-size: var(--toc-font-size);
+    color: var(--page-foreground-color) !important;
+    text-decoration: none;
+}
+
+.doxygen-content div.toc li a:hover, .doxygen-content div.toc li a.active {
+    color: var(--primary-color) !important;
+}
+
+.doxygen-content div.toc li a.aboveActive {
+    color: var(--page-secondary-foreground-color) !important;
+}
+
+
+@media screen and (max-width: 999px) {
+    .doxygen-content div.contents .toc {
+        max-height: 45vh;
+        float: none;
+        width: auto;
+        margin: 0 0 var(--spacing-medium) 0;
+        position: relative;
+        top: 0;
+        position: relative;
+        border: 1px solid var(--separator-color);
+        border-radius: var(--border-radius-medium);
+        background-color: var(--toc-background);
+        box-shadow: var(--box-shadow);
+    }
+
+    .doxygen-content div.contents .toc.interactive {
+        max-height: calc(var(--navigation-font-size) + 2 * var(--spacing-large));
+        overflow: hidden;
+    }
+
+    .doxygen-content div.contents .toc > h3 {
+        -webkit-tap-highlight-color: transparent;
+        cursor: pointer;
+        position: sticky;
+        top: 0;
+        background-color: var(--toc-background);
+        margin: 0;
+        padding: var(--spacing-large) 0;
+        display: block;
+    }
+
+    .doxygen-content div.contents .toc.interactive > h3::before {
+        content: "";
+        width: 0; 
+        height: 0; 
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid var(--primary-color);
+        display: inline-block;
+        margin-right: var(--spacing-small);
+        margin-bottom: calc(var(--navigation-font-size) / 4);
+        transform: rotate(-90deg);
+        transition: transform 0.25s ease-out;
+    }
+
+    .doxygen-content div.contents .toc.interactive.open > h3::before {
+        transform: rotate(0deg);
+    }
+
+    .doxygen-content div.contents .toc.interactive.open {
+        max-height: 45vh;
+        overflow: auto;
+        transition: max-height 0.2s ease-in-out;
+    }
+
+    .doxygen-content div.contents .toc a, .doxygen-content div.contents .toc a.active {
+        color: var(--primary-color) !important;
+    }
+
+    .doxygen-content div.contents .toc a:hover {
+        text-decoration: underline;
+    }
+}
+
+/*
+ Code & Fragments
+ */
+
+.doxygen-content code, .doxygen-content div.fragment, .doxygen-content pre.fragment {
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+}
+
+.doxygen-content code {
+    display: inline;
+    background: var(--code-background);
+    color: var(--code-foreground);
+    padding: 2px 6px;
+}
+
+.doxygen-content div.fragment, .doxygen-content pre.fragment {
+    margin: var(--spacing-medium) 0;
+    padding: calc(var(--spacing-large) - (var(--spacing-large) / 6)) var(--spacing-large);
+    background: var(--fragment-background);
+    color: var(--fragment-foreground);
+    overflow-x: auto;
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content div.fragment, .doxygen-content pre.fragment {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+        border-right: 0;
+    }
+
+    .doxygen-content .contents > div.fragment,
+    .doxygen-content .textblock > div.fragment,
+    .doxygen-content .textblock > pre.fragment,
+    .doxygen-content .contents > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .doxygen-content .textblock > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .doxygen-content .textblock > .doxygen-awesome-fragment-wrapper > pre.fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-large));
+        border-radius: 0;
+        border-left: 0;
+    }
+
+    .doxygen-content .textblock li > .fragment,
+    .doxygen-content .textblock li > .doxygen-awesome-fragment-wrapper > .fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-large));
+    }
+
+    .doxygen-content .memdoc li > .fragment,
+    .doxygen-content .memdoc li > .doxygen-awesome-fragment-wrapper > .fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-medium));
+    }
+
+    .doxygen-content .textblock ul, .doxygen-content .memdoc ul {
+        overflow: initial;
+    }
+
+    .doxygen-content .memdoc > div.fragment,
+    .doxygen-content .memdoc > pre.fragment,
+    .doxygen-content dl dd > div.fragment,
+    .doxygen-content dl dd pre.fragment,
+    .doxygen-content .memdoc > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .doxygen-content .memdoc > .doxygen-awesome-fragment-wrapper > pre.fragment,
+    .doxygen-content dl dd > .doxygen-awesome-fragment-wrapper > div.fragment,
+    .doxygen-content dl dd .doxygen-awesome-fragment-wrapper > pre.fragment {
+        margin: var(--spacing-medium) calc(0px - var(--spacing-medium));
+        border-radius: 0;
+        border-left: 0;
+    }
+}
+
+.doxygen-content code, .doxygen-content code a, .doxygen-content pre.fragment, .doxygen-content div.fragment, .doxygen-content div.fragment .line, .doxygen-content div.fragment span, .doxygen-content div.fragment .line a, .doxygen-content div.fragment .line span {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size) !important;
+}
+
+.doxygen-content div.line:after {
+    margin-right: var(--spacing-medium);
+}
+
+.doxygen-content div.fragment .line, .doxygen-content pre.fragment {
+    white-space: pre;
+    word-wrap: initial;
+    line-height: var(--fragment-lineheight);
+}
+
+.doxygen-content div.fragment span.keyword {
+    color: var(--fragment-keyword);
+}
+
+.doxygen-content div.fragment span.keywordtype {
+    color: var(--fragment-keywordtype);
+}
+
+.doxygen-content div.fragment span.keywordflow {
+    color: var(--fragment-keywordflow);
+}
+
+.doxygen-content div.fragment span.stringliteral {
+    color: var(--fragment-token)
+}
+
+.doxygen-content div.fragment span.comment {
+    color: var(--fragment-comment);
+}
+
+.doxygen-content div.fragment a.code {
+    color: var(--fragment-link) !important;
+}
+
+.doxygen-content div.fragment span.preprocessor {
+    color: var(--fragment-preprocessor);
+}
+
+.doxygen-content div.fragment span.lineno {
+    display: inline-block;
+    width: 27px;
+    border-right: none;
+    background: var(--fragment-linenumber-background);
+    color: var(--fragment-linenumber-color);
+}
+
+.doxygen-content div.fragment span.lineno a {
+    background: none;
+    color: var(--fragment-link) !important;
+}
+
+.doxygen-content div.fragment .line:first-child .lineno {
+    box-shadow: -999999px 0px 0 999999px var(--fragment-linenumber-background), -999998px 0px 0 999999px var(--fragment-linenumber-border);
+}
+
+.doxygen-content div.line {
+    border-radius: var(--border-radius-small);
+}
+
+.doxygen-content div.line.glow {
+    background-color: var(--primary-light-color);
+    box-shadow: none;
+}
+
+/*
+ dl warning, attention, note, deprecated, bug, ...
+ */
+
+.doxygen-content dl.bug dt a, .doxygen-content dl.deprecated dt a, .doxygen-content dl.todo dt a {
+    font-weight: bold !important;
+}
+
+.doxygen-content dl.warning, .doxygen-content dl.attention, .doxygen-content dl.note, .doxygen-content dl.deprecated, .doxygen-content dl.bug, .doxygen-content dl.invariant, .doxygen-content dl.pre, .doxygen-content dl.post, .doxygen-content dl.todo, .doxygen-content dl.remark {
+    padding: var(--spacing-medium);
+    margin: var(--spacing-medium) 0;
+    color: var(--page-background-color);
+    overflow: hidden;
+    margin-left: 0;
+    border-radius: var(--border-radius-small);
+}
+
+.doxygen-content dl.section dd {
+    margin-bottom: 2px;
+}
+
+.doxygen-content dl.warning, .doxygen-content dl.attention {
+    background: var(--warning-color);
+    border-left: 8px solid var(--warning-color-dark);
+    color: var(--warning-color-darker);
+}
+
+.doxygen-content dl.warning dt, .doxygen-content dl.attention dt {
+    color: var(--warning-color-dark);
+}
+
+.doxygen-content dl.note, .doxygen-content dl.remark {
+    background: var(--note-color);
+    border-left: 8px solid var(--note-color-dark);
+    color: var(--note-color-darker);
+}
+
+.doxygen-content dl.note dt, .doxygen-content dl.remark dt {
+    color: var(--note-color-dark);
+}
+
+.doxygen-content dl.todo {
+    background: var(--todo-color);
+    border-left: 8px solid var(--todo-color-dark);
+    color: var(--todo-color-darker);
+}
+
+.doxygen-content dl.todo dt {
+    color: var(--todo-color-dark);
+}
+
+.doxygen-content dl.bug dt a {
+    color: var(--todo-color-dark) !important;
+}
+
+.doxygen-content dl.bug {
+    background: var(--bug-color);
+    border-left: 8px solid var(--bug-color-dark);
+    color: var(--bug-color-darker);
+}
+
+.doxygen-content dl.bug dt a {
+    color: var(--bug-color-dark) !important;
+}
+
+.doxygen-content dl.deprecated {
+    background: var(--deprecated-color);
+    border-left: 8px solid var(--deprecated-color-dark);
+    color: var(--deprecated-color-darker);
+}
+
+.doxygen-content dl.deprecated dt a {
+    color: var(--deprecated-color-dark) !important;
+}
+
+.doxygen-content dl.section dd, .doxygen-content dl.bug dd, .doxygen-content dl.deprecated dd, .doxygen-content dl.todo dd {
+    margin-inline-start: 0px;
+}
+
+.doxygen-content dl.invariant, .doxygen-content dl.pre, .doxygen-content dl.post {
+    background: var(--invariant-color);
+    border-left: 8px solid var(--invariant-color-dark);
+    color: var(--invariant-color-darker);
+}
+
+.doxygen-content dl.invariant dt, .doxygen-content dl.pre dt, .doxygen-content dl.post dt {
+    color: var(--invariant-color-dark);
+}
+
+/*
+ memitem
+ */
+
+.doxygen-content div.memdoc, .doxygen-content div.memproto, .doxygen-content h2.memtitle {
+    box-shadow: none;
+    background-image: none;
+    border: none;
+}
+
+.doxygen-content div.memdoc {
+    padding: 0 var(--spacing-medium);
+    background: var(--page-background-color);
+}
+
+.doxygen-content h2.memtitle, .doxygen-content div.memitem {
+    border: 1px solid var(--separator-color);
+    box-shadow: var(--box-shadow);
+}
+
+.doxygen-content h2.memtitle {
+    box-shadow: 0px var(--spacing-medium) 0 -1px var(--fragment-background), var(--box-shadow);
+}
+
+.doxygen-content div.memitem {
+    transition: none;
+}
+
+.doxygen-content div.memproto, .doxygen-content h2.memtitle {
+    background: var(--fragment-background);
+}
+
+.doxygen-content h2.memtitle {
+    font-weight: 500;
+    font-size: var(--memtitle-font-size);
+    font-family: var(--font-family-monospace);
+    border-bottom: none;
+    border-top-left-radius: var(--border-radius-medium);
+    border-top-right-radius: var(--border-radius-medium);
+    word-break: break-all;
+    position: relative;
+}
+
+.doxygen-content h2.memtitle:after {
+    content: "";
+    display: block;
+    background: var(--fragment-background);
+    height: var(--spacing-medium);
+    bottom: calc(0px - var(--spacing-medium));
+    left: 0;
+    right: -14px;
+    position: absolute;
+    border-top-right-radius: var(--border-radius-medium);
+}
+
+.doxygen-content h2.memtitle > span.permalink {
+    font-size: inherit;
+}
+
+.doxygen-content h2.memtitle > span.permalink > a {
+    text-decoration: none;
+    padding-left: 3px;
+    margin-right: -4px;
+    user-select: none;
+    display: inline-block;
+    margin-top: -6px;
+}
+
+.doxygen-content h2.memtitle > span.permalink > a:hover {
+    color: var(--primary-dark-color) !important;
+}
+
+.doxygen-content a:target + h2.memtitle, .doxygen-content a:target + h2.memtitle + div.memitem {
+    border-color: var(--primary-light-color);
+}
+
+.doxygen-content div.memitem {
+    border-top-right-radius: var(--border-radius-medium);
+    border-bottom-right-radius: var(--border-radius-medium);
+    border-bottom-left-radius: var(--border-radius-medium);
+    overflow: hidden;
+    display: block !important;
+}
+
+.doxygen-content div.memdoc {
+    border-radius: 0;
+}
+
+.doxygen-content div.memproto {
+    border-radius: 0 var(--border-radius-small) 0 0;
+    overflow: auto;
+    border-bottom: 1px solid var(--separator-color);
+    padding: var(--spacing-medium);
+    margin-bottom: -1px;
+}
+
+.doxygen-content div.memtitle {
+    border-top-right-radius: var(--border-radius-medium);
+    border-top-left-radius: var(--border-radius-medium);
+}
+
+.doxygen-content div.memproto table.memname {
+    font-family: var(--font-family-monospace);
+    color: var(--page-foreground-color);
+    font-size: var(--memname-font-size);
+    text-shadow: none;
+}
+
+.doxygen-content div.memproto div.memtemplate {
+    font-family: var(--font-family-monospace);
+    color: var(--primary-dark-color);
+    font-size: var(--memname-font-size);
+    margin-left: 2px;
+    text-shadow: none;
+}
+
+.doxygen-content table.mlabels, .doxygen-content table.mlabels > tbody {
+    display: block;
+}
+
+.doxygen-content td.mlabels-left {
+    width: auto;
+}
+
+.doxygen-content td.mlabels-right {
+    margin-top: 3px;
+    position: sticky;
+    left: 0;
+}
+
+.doxygen-content table.mlabels > tbody > tr:first-child {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.doxygen-content .memname, .doxygen-content .memitem span.mlabels {
+    margin: 0
+}
+
+/*
+ reflist
+ */
+
+.doxygen-content dl.reflist {
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius-medium);
+    border: 1px solid var(--separator-color);
+    overflow: hidden;
+    padding: 0;
+}
+
+
+.doxygen-content dl.reflist dt, .doxygen-content dl.reflist dd {
+    box-shadow: none;
+    text-shadow: none;
+    background-image: none;
+    border: none;
+    padding: 12px;
+}
+
+
+.doxygen-content dl.reflist dt {
+    font-weight: 500;
+    border-radius: 0;
+    background: var(--code-background);
+    border-bottom: 1px solid var(--separator-color);
+    color: var(--page-foreground-color)
+}
+
+
+.doxygen-content dl.reflist dd {
+    background: none;
+}
+
+/*
+ Table
+ */
+
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname),
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: inline-block;
+    max-width: 100%;
+}
+
+.doxygen-content .contents > table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname):not(.classindex) {
+    margin-left: calc(0px - var(--spacing-large));
+    margin-right: calc(0px - var(--spacing-large));
+    max-width: calc(100% + 2 * var(--spacing-large));
+}
+
+.doxygen-content table.fieldtable,
+.doxygen-content table.markdownTable tbody,
+.doxygen-content table.doxtable tbody {
+    border: none;
+    margin: var(--spacing-medium) 0;
+    box-shadow: 0 0 0 1px var(--separator-color);
+    border-radius: var(--border-radius-small);
+}
+
+.doxygen-content table.markdownTable, .doxygen-content table.doxtable, .doxygen-content table.fieldtable {
+    padding: 1px;
+}
+
+.doxygen-content table.doxtable caption {
+    display: block;
+}
+
+.doxygen-content table.fieldtable {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.doxygen-content th.markdownTableHeadLeft,
+.doxygen-content th.markdownTableHeadRight,
+.doxygen-content th.markdownTableHeadCenter,
+.doxygen-content th.markdownTableHeadNone,
+.doxygen-content table.doxtable th {
+    background: var(--tablehead-background);
+    color: var(--tablehead-foreground);
+    font-weight: 600;
+    font-size: var(--page-font-size);
+}
+
+.doxygen-content th.markdownTableHeadLeft:first-child,
+.doxygen-content th.markdownTableHeadRight:first-child,
+.doxygen-content th.markdownTableHeadCenter:first-child,
+.doxygen-content th.markdownTableHeadNone:first-child,
+.doxygen-content table.doxtable tr th:first-child {
+    border-top-left-radius: var(--border-radius-small);
+}
+
+.doxygen-content th.markdownTableHeadLeft:last-child,
+.doxygen-content th.markdownTableHeadRight:last-child,
+.doxygen-content th.markdownTableHeadCenter:last-child,
+.doxygen-content th.markdownTableHeadNone:last-child,
+.doxygen-content table.doxtable tr th:last-child {
+    border-top-right-radius: var(--border-radius-small);
+}
+
+.doxygen-content table.markdownTable td,
+.doxygen-content table.markdownTable th,
+.doxygen-content table.fieldtable td,
+.doxygen-content table.fieldtable th,
+.doxygen-content table.doxtable td,
+.doxygen-content table.doxtable th {
+    border: 1px solid var(--separator-color);
+    padding: var(--spacing-small) var(--spacing-medium);
+}
+
+.doxygen-content table.markdownTable td:last-child,
+.doxygen-content table.markdownTable th:last-child,
+.doxygen-content table.fieldtable td:last-child,
+.doxygen-content table.fieldtable th:last-child,
+.doxygen-content table.doxtable td:last-child,
+.doxygen-content table.doxtable th:last-child {
+    border-right: none;
+}
+
+.doxygen-content table.markdownTable td:first-child,
+.doxygen-content table.markdownTable th:first-child,
+.doxygen-content table.fieldtable td:first-child,
+.doxygen-content table.fieldtable th:first-child,
+.doxygen-content table.doxtable td:first-child,
+.doxygen-content table.doxtable th:first-child {
+    border-left: none;
+}
+
+.doxygen-content table.markdownTable tr:first-child td,
+.doxygen-content table.markdownTable tr:first-child th,
+.doxygen-content table.fieldtable tr:first-child td,
+.doxygen-content table.fieldtable tr:first-child th,
+.doxygen-content table.doxtable tr:first-child td,
+.doxygen-content table.doxtable tr:first-child th {
+    border-top: none;
+}
+
+.doxygen-content table.markdownTable tr:last-child td,
+.doxygen-content table.markdownTable tr:last-child th,
+.doxygen-content table.fieldtable tr:last-child td,
+.doxygen-content table.fieldtable tr:last-child th,
+.doxygen-content table.doxtable tr:last-child td,
+.doxygen-content table.doxtable tr:last-child th {
+    border-bottom: none;
+}
+
+.doxygen-content table.markdownTable tr, .doxygen-content table.doxtable tr {
+    border-bottom: 1px solid var(--separator-color);
+}
+
+.doxygen-content table.markdownTable tr:last-child, .doxygen-content table.doxtable tr:last-child {
+    border-bottom: none;
+}
+
+.doxygen-content .full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) {
+    display: block;
+}
+
+.doxygen-content .full_width_table table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody {
+    display: table;
+    width: 100%;
+}
+
+.doxygen-content table.fieldtable th {
+    font-size: var(--page-font-size);
+    font-weight: 600;
+    background-image: none;
+    background-color: var(--tablehead-background);
+    color: var(--tablehead-foreground);
+}
+
+.doxygen-content table.fieldtable td.fieldtype, .doxygen-content .fieldtable td.fieldname, .doxygen-content .fieldtable td.fielddoc, .doxygen-content .fieldtable th {
+    border-bottom: 1px solid var(--separator-color);
+    border-right: 1px solid var(--separator-color);
+}
+
+.doxygen-content table.fieldtable tr:last-child td:first-child {
+    border-bottom-left-radius: var(--border-radius-small);
+}
+
+.doxygen-content table.fieldtable tr:last-child td:last-child {
+    border-bottom-right-radius: var(--border-radius-small);
+}
+
+.doxygen-content .memberdecls td.glow, .doxygen-content .fieldtable tr.glow {
+    background-color: var(--primary-light-color);
+    box-shadow: none;
+}
+
+.doxygen-content table.memberdecls {
+    display: block;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.doxygen-content table.memberdecls tr[class^="memitem"] {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+}
+
+.doxygen-content table.memberdecls tr[class^="memitem"] .memTemplParams {
+    font-family: var(--font-family-monospace);
+    font-size: var(--code-font-size);
+    color: var(--primary-dark-color);
+    white-space: normal;
+}
+
+.doxygen-content table.memberdecls .memItemLeft,
+.doxygen-content table.memberdecls .memItemRight,
+.doxygen-content table.memberdecls .memTemplItemLeft,
+.doxygen-content table.memberdecls .memTemplItemRight,
+.doxygen-content table.memberdecls .memTemplParams {
+    transition: none;
+    padding-top: var(--spacing-small);
+    padding-bottom: var(--spacing-small);
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    background-color: var(--fragment-background);
+}
+
+.doxygen-content table.memberdecls .memTemplItemLeft,
+.doxygen-content table.memberdecls .memTemplItemRight {
+    padding-top: 2px;
+}
+
+.doxygen-content table.memberdecls .memTemplParams {
+    border-bottom: 0;
+    border-left: 1px solid var(--separator-color);
+    border-right: 1px solid var(--separator-color);
+    border-radius: var(--border-radius-small) var(--border-radius-small) 0 0;
+    padding-bottom: var(--spacing-small);
+}
+
+.doxygen-content table.memberdecls .memTemplItemLeft {
+    border-radius: 0 0 0 var(--border-radius-small);
+    border-left: 1px solid var(--separator-color);
+    border-top: 0;
+}
+
+.doxygen-content table.memberdecls .memTemplItemRight {
+    border-radius: 0 0 var(--border-radius-small) 0;
+    border-right: 1px solid var(--separator-color);
+    padding-left: 0;
+    border-top: 0;
+}
+
+.doxygen-content table.memberdecls .memItemLeft {
+    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+    border-left: 1px solid var(--separator-color);
+    padding-left: var(--spacing-medium);
+    padding-right: 0;
+}
+
+.doxygen-content table.memberdecls .memItemRight  {
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+    border-right: 1px solid var(--separator-color);
+    padding-right: var(--spacing-medium);
+    padding-left: 0;
+
+}
+
+.doxygen-content table.memberdecls .mdescLeft, .doxygen-content table.memberdecls .mdescRight {
+    background: none;
+    color: var(--page-foreground-color);
+    padding: var(--spacing-small) 0;
+}
+
+.doxygen-content table.memberdecls .memItemLeft,
+.doxygen-content table.memberdecls .memTemplItemLeft {
+    padding-right: var(--spacing-medium);
+}
+
+.doxygen-content table.memberdecls .memSeparator {
+    background: var(--page-background-color);
+    height: var(--spacing-large);
+    border: 0;
+    transition: none;
+}
+
+.doxygen-content table.memberdecls .groupheader {
+    margin-bottom: var(--spacing-large);
+}
+
+.doxygen-content table.memberdecls .inherit_header td {
+    padding: 0 0 var(--spacing-medium) 0;
+    text-indent: -12px;
+    color: var(--page-secondary-foreground-color);
+}
+
+.doxygen-content table.memberdecls img[src="closed.png"],
+.doxygen-content table.memberdecls img[src="open.png"],
+.doxygen-content div.dynheader img[src="open.png"],
+.doxygen-content div.dynheader img[src="closed.png"] {
+    width: 0; 
+    height: 0; 
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 5px solid var(--primary-color);
+    margin-top: 8px;
+    display: block;
+    float: left;
+    margin-left: -10px;
+    transition: transform 0.25s ease-out;
+}
+
+.doxygen-content table.memberdecls img {
+    margin-right: 10px;
+}
+
+.doxygen-content table.memberdecls img[src="closed.png"],
+.doxygen-content div.dynheader img[src="closed.png"] {
+    transform: rotate(-90deg);
+    
+}
+
+.doxygen-content .compoundTemplParams {
+    font-family: var(--font-family-monospace);
+    color: var(--primary-dark-color);
+    font-size: var(--code-font-size);
+}
+
+@media screen and (max-width: 767px) {
+
+    .doxygen-content table.memberdecls .memItemLeft,
+    .doxygen-content table.memberdecls .memItemRight,
+    .doxygen-content table.memberdecls .mdescLeft,
+    .doxygen-content table.memberdecls .mdescRight,
+    .doxygen-content table.memberdecls .memTemplItemLeft,
+    .doxygen-content table.memberdecls .memTemplItemRight,
+    .doxygen-content table.memberdecls .memTemplParams {
+        display: block;
+        text-align: left;
+        padding-left: var(--spacing-large);
+        margin: 0 calc(0px - var(--spacing-large)) 0 calc(0px - var(--spacing-large));
+        border-right: none;
+        border-left: none;
+        border-radius: 0;
+        white-space: normal;
+    }
+
+    .doxygen-content table.memberdecls .memItemLeft,
+    .doxygen-content table.memberdecls .mdescLeft,
+    .doxygen-content table.memberdecls .memTemplItemLeft {
+        border-bottom: 0;
+        padding-bottom: 0;
+    }
+
+    .doxygen-content table.memberdecls .memTemplItemLeft {
+        padding-top: 0;
+    }
+
+    .doxygen-content table.memberdecls .mdescLeft {
+        margin-bottom: calc(0px - var(--page-font-size));
+    }
+
+    .doxygen-content table.memberdecls .memItemRight, 
+    .doxygen-content table.memberdecls .mdescRight,
+    .doxygen-content table.memberdecls .memTemplItemRight {
+        border-top: 0;
+        padding-top: 0;
+        padding-right: var(--spacing-large);
+        overflow-x: auto;
+    }
+
+    .doxygen-content table.memberdecls tr[class^="memitem"]:not(.inherit) {
+        display: block;
+        width: calc(100vw - 2 * var(--spacing-large));
+    }
+
+    .doxygen-content table.memberdecls .mdescRight {
+        color: var(--page-foreground-color);
+    }
+
+    .doxygen-content table.memberdecls tr.inherit {
+        visibility: hidden;
+    }
+
+    .doxygen-content table.memberdecls tr[style="display: table-row;"] {
+        display: block !important;
+        visibility: visible;
+        width: calc(100vw - 2 * var(--spacing-large));
+        animation: fade .5s;
+    }
+
+    @keyframes fade {
+        0% {
+            opacity: 0;
+            max-height: 0;
+        }
+
+        100% {
+            opacity: 1;
+            max-height: 200px;
+        }
+    }
+}
+
+
+/*
+ Horizontal Rule
+ */
+
+.doxygen-content hr {
+    margin-top: var(--spacing-large);
+    margin-bottom: var(--spacing-large);
+    height: 1px;
+    background-color: var(--separator-color);
+    border: 0;
+}
+
+.doxygen-content .contents hr {
+    border-bottom: 1px solid var(--separator-color);
+}
+
+.doxygen-content .contents img, .doxygen-content .contents .center, .doxygen-content .contents center, .doxygen-content .contents div.image object {
+    max-width: 100%;
+    overflow: auto;
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content .contents .dyncontent > .center, .doxygen-content .contents > center {
+        margin-left: calc(0px - var(--spacing-large));
+        margin-right: calc(0px - var(--spacing-large));
+        max-width: calc(100% + 2 * var(--spacing-large));
+    }
+}
+
+/*
+ Directories
+ */
+.doxygen-content div.directory {
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    width: auto;
+}
+
+.doxygen-content table.directory {
+    font-family: var(--font-family);
+    font-size: var(--page-font-size);
+    font-weight: normal;
+    width: 100%;
+}
+
+.doxygen-content table.directory td.entry, .doxygen-content table.directory td.desc {
+    padding: calc(var(--spacing-small) / 2) var(--spacing-small);
+    line-height: var(--table-line-height);
+}
+
+.doxygen-content table.directory tr.even td:last-child {
+    border-radius: 0 var(--border-radius-small) var(--border-radius-small) 0;
+}
+
+.doxygen-content table.directory tr.even td:first-child {
+    border-radius: var(--border-radius-small) 0 0 var(--border-radius-small);
+}
+
+.doxygen-content table.directory tr.even:last-child td:last-child {
+    border-radius: 0 var(--border-radius-small) 0 0;
+}
+
+.doxygen-content table.directory tr.even:last-child td:first-child {
+    border-radius: var(--border-radius-small) 0 0 0;
+}
+
+.doxygen-content table.directory td.desc {
+    min-width: 250px;
+}
+
+.doxygen-content table.directory tr.even {
+    background-color: var(--odd-color);
+}
+
+.doxygen-content table.directory tr.odd {
+    background-color: transparent;
+}
+
+.doxygen-content .icona {
+    width: auto;
+    height: auto;
+    margin: 0 var(--spacing-small);
+}
+
+.doxygen-content .icon {
+    background: var(--primary-color);
+    border-radius: var(--border-radius-small);
+    font-size: var(--page-font-size);
+    padding: calc(var(--page-font-size) / 5);
+    line-height: var(--page-font-size);
+    transform: scale(0.8);
+    height: auto;
+    width: var(--page-font-size);
+    user-select: none;
+}
+
+.doxygen-content .iconfopen, .doxygen-content .icondoc, .doxygen-content .iconfclosed {
+    background-position: center;
+    margin-bottom: 0;
+    height: var(--table-line-height);
+}
+
+.doxygen-content .icondoc {
+    filter: saturate(0.2);
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content div.directory {
+        margin-left: calc(0px - var(--spacing-large));
+        margin-right: calc(0px - var(--spacing-large));
+    }
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) .doxygen-content .iconfopen, html:not([data-theme=light]) .doxygen-content .iconfclosed {
+        filter: hue-rotate(180deg) invert();
+    }
+}
+
+html[data-theme=dark] .doxygen-content .iconfopen, html[data-theme=dark] .doxygen-content .iconfclosed {
+    filter: hue-rotate(180deg) invert();
+}
+
+/*
+ Class list
+ */
+
+.doxygen-content .classindex dl.odd {
+    background: var(--odd-color);
+    border-radius: var(--border-radius-small);
+}
+
+.doxygen-content .classindex dl.even {
+    background-color: transparent;
+}
+
+/* 
+ Class Index Doxygen 1.8 
+*/
+
+.doxygen-content table.classindex {
+    margin-left: 0;
+    margin-right: 0;
+    width: 100%;
+}
+
+.doxygen-content table.classindex table div.ah {
+    background-image: none;
+    background-color: initial;
+    border-color: var(--separator-color);
+    color: var(--page-foreground-color);
+    box-shadow: var(--box-shadow);
+    border-radius: var(--border-radius-large);
+    padding: var(--spacing-small);
+}
+
+.doxygen-content div.qindex {
+    background-color: var(--odd-color);
+    border-radius: var(--border-radius-small);
+    border: 1px solid var(--separator-color);
+    padding: var(--spacing-small) 0;
+}
+
+/*
+  Footer and nav-path
+ */
+
+.doxygen-content #nav-path {
+    width: 100%;
+}
+
+.doxygen-content #nav-path ul {
+    background-image: none;
+    background: var(--page-background-color);
+    border: none;
+    border-top: 1px solid var(--separator-color);
+    border-bottom: 1px solid var(--separator-color);
+    border-bottom: 0;
+    box-shadow: 0 0.75px 0 var(--separator-color);
+    font-size: var(--navigation-font-size);
+}
+
+.doxygen-content img.footer {
+    width: 60px;
+}
+
+.doxygen-content .navpath li.footer {
+    color: var(--page-secondary-foreground-color);
+}
+
+.doxygen-content address.footer {
+    color: var(--page-secondary-foreground-color);
+    margin-bottom: var(--spacing-large);
+}
+
+.doxygen-content #nav-path li.navelem {
+    background-image: none;
+    display: flex;
+    align-items: center;
+}
+
+.doxygen-content .navpath li.navelem a {
+    text-shadow: none;
+    display: inline-block;
+    color: var(--primary-color) !important;
+}
+
+.doxygen-content .navpath li.navelem b {
+    color: var(--primary-dark-color);
+    font-weight: 500;
+}
+
+.doxygen-content li.navelem {
+    padding: 0;
+    margin-left: -8px;
+}
+
+.doxygen-content li.navelem:first-child {
+    margin-left: var(--spacing-large);
+}
+
+.doxygen-content li.navelem:first-child:before {
+    display: none;
+}
+
+.doxygen-content #nav-path li.navelem:after {
+    content: "";
+    border: 5px solid var(--page-background-color);
+    border-bottom-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    transform: translateY(-1px) scaleY(4.2);
+    z-index: 10;
+    margin-left: 6px;
+}
+
+.doxygen-content #nav-path li.navelem:before {
+    content: "";
+    border: 5px solid var(--separator-color);
+    border-bottom-color: transparent;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    transform: translateY(-1px) scaleY(3.2);
+    margin-right: var(--spacing-small);
+}
+
+.doxygen-content .navpath li.navelem a:hover {
+    color: var(--primary-color);
+}
+
+/*
+ Scrollbars for Webkit
+*/
+
+.doxygen-content #nav-tree::-webkit-scrollbar,
+.doxygen-content div.fragment::-webkit-scrollbar,
+.doxygen-content pre.fragment::-webkit-scrollbar,
+.doxygen-content div.memproto::-webkit-scrollbar,
+.doxygen-content .contents center::-webkit-scrollbar,
+.doxygen-content .contents .center::-webkit-scrollbar,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar,
+.doxygen-content div.contents .toc::-webkit-scrollbar,
+.doxygen-content .contents .dotgraph::-webkit-scrollbar,
+.doxygen-content .contents .tabs-overview-container::-webkit-scrollbar {
+    background: transparent;
+    width: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+    height: calc(var(--webkit-scrollbar-size) + var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+}
+
+.doxygen-content #nav-tree::-webkit-scrollbar-thumb,
+.doxygen-content div.fragment::-webkit-scrollbar-thumb,
+.doxygen-content pre.fragment::-webkit-scrollbar-thumb,
+.doxygen-content div.memproto::-webkit-scrollbar-thumb,
+.doxygen-content .contents center::-webkit-scrollbar-thumb,
+.doxygen-content .contents .center::-webkit-scrollbar-thumb,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-thumb,
+.doxygen-content div.contents .toc::-webkit-scrollbar-thumb,
+.doxygen-content .contents .dotgraph::-webkit-scrollbar-thumb,
+.doxygen-content .contents .tabs-overview-container::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border: var(--webkit-scrollbar-padding) solid transparent;
+    border-radius: calc(var(--webkit-scrollbar-padding) + var(--webkit-scrollbar-padding));
+    background-clip: padding-box;  
+}
+
+.doxygen-content #nav-tree:hover::-webkit-scrollbar-thumb,
+.doxygen-content div.fragment:hover::-webkit-scrollbar-thumb,
+.doxygen-content pre.fragment:hover::-webkit-scrollbar-thumb,
+.doxygen-content div.memproto:hover::-webkit-scrollbar-thumb,
+.doxygen-content .contents center:hover::-webkit-scrollbar-thumb,
+.doxygen-content .contents .center:hover::-webkit-scrollbar-thumb,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody:hover::-webkit-scrollbar-thumb,
+.doxygen-content div.contents .toc:hover::-webkit-scrollbar-thumb,
+.doxygen-content .contents .dotgraph:hover::-webkit-scrollbar-thumb,
+.doxygen-content .contents .tabs-overview-container:hover::-webkit-scrollbar-thumb {
+    background-color: var(--webkit-scrollbar-color);
+}
+
+.doxygen-content #nav-tree::-webkit-scrollbar-track,
+.doxygen-content div.fragment::-webkit-scrollbar-track,
+.doxygen-content pre.fragment::-webkit-scrollbar-track,
+.doxygen-content div.memproto::-webkit-scrollbar-track,
+.doxygen-content .contents center::-webkit-scrollbar-track,
+.doxygen-content .contents .center::-webkit-scrollbar-track,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody::-webkit-scrollbar-track,
+.doxygen-content div.contents .toc::-webkit-scrollbar-track,
+.doxygen-content .contents .dotgraph::-webkit-scrollbar-track,
+.doxygen-content .contents .tabs-overview-container::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.doxygen-content #nav-tree::-webkit-scrollbar-corner {
+    background-color: var(--side-nav-background);
+}
+
+.doxygen-content #nav-tree,
+.doxygen-content div.fragment,
+.doxygen-content pre.fragment,
+.doxygen-content div.memproto,
+.doxygen-content .contents center,
+.doxygen-content .contents .center,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+.doxygen-content div.contents .toc {
+    overflow-x: auto;
+    overflow-x: overlay;
+}
+
+.doxygen-content #nav-tree {
+    overflow-x: auto;
+    overflow-y: auto;
+    overflow-y: overlay;
+}
+
+/*
+ Scrollbars for Firefox
+*/
+
+.doxygen-content #nav-tree,
+.doxygen-content div.fragment,
+.doxygen-content pre.fragment,
+.doxygen-content div.memproto,
+.doxygen-content .contents center,
+.doxygen-content .contents .center,
+.doxygen-content .contents table:not(.memberdecls):not(.mlabels):not(.fieldtable):not(.memname) tbody,
+.doxygen-content div.contents .toc,
+.doxygen-content .contents .dotgraph,
+.doxygen-content .contents .tabs-overview-container {
+    scrollbar-width: thin;
+}
+
+/*
+  Optional Dark mode toggle button
+*/
+
+.doxygen-content doxygen-awesome-dark-mode-toggle {
+    display: inline-block;
+    margin: 0 0 0 var(--spacing-small);
+    padding: 0;
+    width: var(--searchbar-height);
+    height: var(--searchbar-height);
+    background: none;
+    border: none;
+    border-radius: var(--searchbar-height);
+    vertical-align: middle;
+    text-align: center;
+    line-height: var(--searchbar-height);
+    font-size: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    cursor: pointer;
+}
+
+.doxygen-content doxygen-awesome-dark-mode-toggle > svg {
+    transition: transform .1s ease-in-out;
+}
+
+.doxygen-content doxygen-awesome-dark-mode-toggle:active > svg {
+    transform: scale(.5);
+}
+
+.doxygen-content doxygen-awesome-dark-mode-toggle:hover {
+    background-color: rgba(0,0,0,.03);
+}
+
+html[data-theme=dark] .doxygen-content doxygen-awesome-dark-mode-toggle:hover {
+    background-color: rgba(0,0,0,.18);
+}
+
+/*
+ Optional fragment copy button
+*/
+.doxygen-content .doxygen-awesome-fragment-wrapper {
+    position: relative;
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button {
+    opacity: 0;
+    background: var(--fragment-background);
+    width: 28px;
+    height: 28px;
+    position: absolute;
+    right: calc(var(--spacing-large) - (var(--spacing-large) / 2.5));
+    top: calc(var(--spacing-large) - (var(--spacing-large) / 2.5));
+    border: 1px solid var(--fragment-foreground);
+    cursor: pointer;
+    border-radius: var(--border-radius-small);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.doxygen-content .doxygen-awesome-fragment-wrapper:hover doxygen-awesome-fragment-copy-button, .doxygen-content doxygen-awesome-fragment-copy-button.success {
+    opacity: .28;
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button:hover, .doxygen-content doxygen-awesome-fragment-copy-button.success {
+    opacity: 1 !important;
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button:active:not([class~=success]) svg {
+    transform: scale(.91);
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button svg {
+    fill: var(--fragment-foreground);
+    width: 18px;
+    height: 18px;
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button.success svg {
+    fill: rgb(14, 168, 14);
+}
+
+.doxygen-content doxygen-awesome-fragment-copy-button.success {
+    border-color: rgb(14, 168, 14);
+}
+
+@media screen and (max-width: 767px) {
+    .doxygen-content .textblock > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .doxygen-content .textblock li > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .doxygen-content .memdoc li > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .doxygen-content .memdoc > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button,
+    .doxygen-content dl dd > .doxygen-awesome-fragment-wrapper > doxygen-awesome-fragment-copy-button {
+        right: 0;
+    }
+}
+
+/*
+ Optional paragraph link button
+*/
+
+.doxygen-content a.anchorlink {
+    font-size: 90%;
+    margin-left: var(--spacing-small);
+    color: var(--page-foreground-color) !important;
+    text-decoration: none;
+    opacity: .15;
+    display: none;
+    transition: opacity .1s ease-in-out, color .1s ease-in-out;
+}
+
+.doxygen-content a.anchorlink svg {
+    fill: var(--page-foreground-color);
+}
+
+.doxygen-content h3 a.anchorlink svg, .doxygen-content h4 a.anchorlink svg {
+    margin-bottom: -3px;
+    margin-top: -4px;
+}
+
+.doxygen-content a.anchorlink:hover {
+    opacity: .45;
+}
+
+.doxygen-content h2:hover a.anchorlink, .doxygen-content h1:hover a.anchorlink, .doxygen-content h3:hover a.anchorlink, .doxygen-content h4:hover a.anchorlink  {
+    display: inline-block;
+}
+
+/*
+ Optional tab feature
+*/
+
+.doxygen-content .tabbed ul {
+    padding-inline-start: 0px;
+    margin: 0;
+    padding: var(--spacing-small) 0;
+    border-bottom: 1px solid var(--separator-color);
+}
+
+.doxygen-content .tabbed li {
+    display: none;
+}
+
+.doxygen-content .tabbed li.selected {
+    display: block;
+}
+
+.doxygen-content .tabs-overview-container {
+    overflow-x: auto;
+    display: block;
+    overflow-y: visible;
+}
+
+.doxygen-content .tabs-overview {
+    border-bottom: 1px solid var(--separator-color);
+    display: flex;
+    flex-direction: row;
+}
+
+.doxygen-content .tabs-overview button.tab-button {
+    color: var(--page-foreground-color);
+    margin: 0;
+    border: none;
+    background: transparent;
+    padding: var(--spacing-small) 0;
+    display: inline-block;
+    font-size: var(--page-font-size);
+    cursor: pointer;
+    box-shadow: 0 1px 0 0 var(--separator-color);
+}
+
+.doxygen-content .tabs-overview button.tab-button .tab-title {
+    float: left;
+    white-space: nowrap;
+    padding: var(--spacing-small) var(--spacing-large);
+    border-radius: var(--border-radius-medium);
+}
+
+.doxygen-content .tabs-overview button.tab-button:not(:last-child) .tab-title {
+    box-shadow: 8px 0 0 -7px var(--separator-color);
+}
+
+.doxygen-content .tabs-overview button.tab-button:hover .tab-title {
+    background: var(--primary-color);
+    color: var(--page-background-color);
+    box-shadow: none;
+}
+
+.doxygen-content .tabs-overview button.tab-button.active {
+    color: var(--primary-color);
+    box-shadow: 0 1px 0 0 var(--primary-color), inset 0 -1px 0 0 var(--primary-color);
+}
+
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) .doxygen-content .tabs-overview button.tab-button:hover .tab-title {
+        color: var(--page-foreground-color);
+    }
+}
+
+html[data-theme=dark] .doxygen-content .tabs-overview button.tab-button:hover .tab-title {
+    color: var(--page-foreground-color);
+}

--- a/src/rocm_docs/data/_doxygen/footer.html
+++ b/src/rocm_docs/data/_doxygen/footer.html
@@ -1,0 +1,5 @@
+<!-- HTML footer for doxygen 1.9.6-->
+<!-- start footer part -->
+<!--BEGIN GENERATE_TREEVIEW-->
+</body>
+</html>

--- a/src/rocm_docs/data/_doxygen/header.html
+++ b/src/rocm_docs/data/_doxygen/header.html
@@ -1,0 +1,32 @@
+<!-- HTML header for doxygen 1.9.6-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
+<head>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<script type="text/javascript" src="$relpath^jquery.js"></script>
+<script type="text/javascript" src="$relpath^dynsections.js"></script>
+$treeview
+$search
+$mathjax
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+$extrastylesheet
+</head>
+<body>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->

--- a/src/rocm_docs/data/_doxygen/stylesheet.css
+++ b/src/rocm_docs/data/_doxygen/stylesheet.css
@@ -1,0 +1,1675 @@
+/* The standard CSS for doxygen 1.9.6*/
+
+.doxygen-content {
+    background-color: white;
+    color: black;
+}
+
+.doxygen-content, .doxygen-content table, .doxygen-content div, .doxygen-content p, .doxygen-content dl {
+	font-weight: 400;
+	font-size: 14px;
+	font-family: Roboto,sans-serif;
+	line-height: 22px;
+}
+
+/* @group Heading Levels */
+
+.doxygen-content .title {
+	font-weight: 400;
+	font-size: 14px;
+	font-family: Roboto,sans-serif;
+	line-height: 28px;
+	font-size: 150%;
+	font-weight: bold;
+	margin: 10px 2px;
+}
+
+.doxygen-content h1.groupheader {
+	font-size: 150%;
+}
+
+.doxygen-content h2.groupheader {
+	border-bottom: 1px solid #879ECB;
+	color: #354C7B;
+	font-size: 150%;
+	font-weight: normal;
+	margin-top: 1.75em;
+	padding-top: 8px;
+	padding-bottom: 4px;
+	width: 100%;
+}
+
+.doxygen-content h3.groupheader {
+	font-size: 100%;
+}
+
+.doxygen-content h1, .doxygen-content h2, .doxygen-content h3, .doxygen-content h4, .doxygen-content h5, .doxygen-content h6 {
+	-webkit-transition: text-shadow 0.5s linear;
+	-moz-transition: text-shadow 0.5s linear;
+	-ms-transition: text-shadow 0.5s linear;
+	-o-transition: text-shadow 0.5s linear;
+	transition: text-shadow 0.5s linear;
+	margin-right: 15px;
+}
+
+.doxygen-content h1.glow, .doxygen-content h2.glow, .doxygen-content h3.glow, .doxygen-content h4.glow, .doxygen-content h5.glow, .doxygen-content h6.glow {
+	text-shadow: 0 0 15px cyan;
+}
+
+.doxygen-content dt {
+	font-weight: bold;
+}
+
+.doxygen-content p.startli, .doxygen-content p.startdd {
+	margin-top: 2px;
+}
+
+.doxygen-content th p.starttd, .doxygen-content th p.intertd, .doxygen-content th p.endtd {
+        font-size: 100%;
+        font-weight: 700;
+}
+
+.doxygen-content p.starttd {
+	margin-top: 0px;
+}
+
+.doxygen-content p.endli {
+	margin-bottom: 0px;
+}
+
+.doxygen-content p.enddd {
+	margin-bottom: 4px;
+}
+
+.doxygen-content p.endtd {
+	margin-bottom: 2px;
+}
+
+.doxygen-content p.interli {
+}
+
+.doxygen-content p.interdd {
+}
+
+.doxygen-content p.intertd {
+}
+
+/* @end */
+
+.doxygen-content caption {
+	font-weight: bold;
+}
+
+.doxygen-content span.legend {
+	font-size: 70%;
+	text-align: center;
+}
+
+.doxygen-content h3.version {
+	font-size: 90%;
+	text-align: center;
+}
+
+.doxygen-content div.navtab {
+	padding-right: 15px;
+	text-align: right;
+	line-height: 110%;
+}
+
+.doxygen-content div.navtab table {
+	border-spacing: 0;
+}
+
+.doxygen-content td.navtab {
+	padding-right: 6px;
+	padding-left: 6px;
+}
+
+.doxygen-content td.navtabHL {
+	background-image: url("tab_a.png");
+	background-repeat:repeat-x;
+	padding-right: 6px;
+	padding-left: 6px;
+}
+
+.doxygen-content td.navtabHL a, .doxygen-content td.navtabHL a:visited {
+	color: white;
+	text-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+}
+
+.doxygen-content a.navtab {
+	font-weight: bold;
+}
+
+.doxygen-content div.qindex{
+	text-align: center;
+	width: 100%;
+	line-height: 140%;
+	font-size: 130%;
+	color: #A0A0A0;
+}
+
+.doxygen-content dt.alphachar{
+	font-size: 180%;
+	font-weight: bold;
+}
+
+.doxygen-content .alphachar a{
+	color: black;
+}
+
+.doxygen-content .alphachar a:hover, .doxygen-content .alphachar a:visited{
+	text-decoration: none;
+}
+
+.doxygen-content .classindex dl {
+	padding: 25px;
+	column-count:1
+}
+
+.doxygen-content .classindex dd {
+	display:inline-block;
+	margin-left: 50px;
+	width: 90%;
+	line-height: 1.15em;
+}
+
+.doxygen-content .classindex dl.even {
+	background-color: white;
+}
+
+.doxygen-content .classindex dl.odd {
+	background-color: #F8F9FC;
+}
+
+@media(min-width: 1120px) {
+	.doxygen-content .classindex dl {
+		column-count:2
+	}
+}
+
+@media(min-width: 1320px) {
+	.doxygen-content .classindex dl {
+		column-count:3
+	}
+}
+
+
+/* @group Link Styling */
+
+.doxygen-content a {
+	color: #3D578C;
+	font-weight: normal;
+	text-decoration: none;
+}
+
+.doxygen-content .contents a:visited {
+	color: #4665A2;
+}
+
+.doxygen-content a:hover {
+	text-decoration: underline;
+}
+
+.doxygen-content a.el {
+	font-weight: bold;
+}
+
+.doxygen-content a.elRef {
+}
+
+.doxygen-content a.code, .doxygen-content a.code:visited, .doxygen-content a.line, .doxygen-content a.line:visited {
+	color: #4665A2;
+}
+
+.doxygen-content a.codeRef, .doxygen-content a.codeRef:visited, .doxygen-content a.lineRef, .doxygen-content a.lineRef:visited {
+	color: #4665A2;
+}
+
+.doxygen-content a.code.hl_class { /* style for links to class names in code snippets */ }
+.doxygen-content a.code.hl_struct { /* style for links to struct names in code snippets */ }
+.doxygen-content a.code.hl_union { /* style for links to union names in code snippets */ }
+.doxygen-content a.code.hl_interface { /* style for links to interface names in code snippets */ }
+.doxygen-content a.code.hl_protocol { /* style for links to protocol names in code snippets */ }
+.doxygen-content a.code.hl_category { /* style for links to category names in code snippets */ }
+.doxygen-content a.code.hl_exception { /* style for links to exception names in code snippets */ }
+.doxygen-content a.code.hl_service { /* style for links to service names in code snippets */ }
+.doxygen-content a.code.hl_singleton { /* style for links to singleton names in code snippets */ }
+.doxygen-content a.code.hl_concept { /* style for links to concept names in code snippets */ }
+.doxygen-content a.code.hl_namespace { /* style for links to namespace names in code snippets */ }
+.doxygen-content a.code.hl_package { /* style for links to package names in code snippets */ }
+.doxygen-content a.code.hl_define { /* style for links to macro names in code snippets */ }
+.doxygen-content a.code.hl_function { /* style for links to function names in code snippets */ }
+.doxygen-content a.code.hl_variable { /* style for links to variable names in code snippets */ }
+.doxygen-content a.code.hl_typedef { /* style for links to typedef names in code snippets */ }
+.doxygen-content a.code.hl_enumvalue { /* style for links to enum value names in code snippets */ }
+.doxygen-content a.code.hl_enumeration { /* style for links to enumeration names in code snippets */ }
+.doxygen-content a.code.hl_signal { /* style for links to Qt signal names in code snippets */ }
+.doxygen-content a.code.hl_slot { /* style for links to Qt slot names in code snippets */ }
+.doxygen-content a.code.hl_friend { /* style for links to friend names in code snippets */ }
+.doxygen-content a.code.hl_dcop { /* style for links to KDE3 DCOP names in code snippets */ }
+.doxygen-content a.code.hl_property { /* style for links to property names in code snippets */ }
+.doxygen-content a.code.hl_event { /* style for links to event names in code snippets */ }
+.doxygen-content a.code.hl_sequence { /* style for links to sequence names in code snippets */ }
+.doxygen-content a.code.hl_dictionary { /* style for links to dictionary names in code snippets */ }
+
+/* @end */
+
+.doxygen-content dl.el {
+	margin-left: -1cm;
+}
+
+.doxygen-content ul {
+  overflow: visible;
+}
+
+.doxygen-content ul.multicol {
+        -moz-column-gap: 1em;
+        -webkit-column-gap: 1em;
+        column-gap: 1em;
+        -moz-column-count: 3;
+        -webkit-column-count: 3;
+        column-count: 3;
+        list-style-type: none;
+}
+
+.doxygen-content #side-nav ul {
+  overflow: visible; /* reset ul rule for scroll bar in GENERATE_TREEVIEW window */
+}
+
+.doxygen-content #main-nav {
+	display: none
+}
+
+.doxygen-content #main-nav ul {
+  overflow: visible; /* reset ul rule for the navigation bar drop down lists */
+}
+
+.doxygen-content .fragment {
+  text-align: left;
+  direction: ltr;
+  overflow-x: auto; /*Fixed: fragment lines overlap floating elements*/
+  overflow-y: hidden;
+}
+
+.doxygen-content pre.fragment {
+        border: 1px solid #C4CFE5;
+        background-color: #FBFCFD;
+	color: black;
+        padding: 4px 6px;
+        margin: 4px 8px 4px 2px;
+        overflow: auto;
+        word-wrap: break-word;
+        font-size:  9pt;
+        line-height: 125%;
+        font-family: monospace,fixed;
+        font-size: 105%;
+}
+
+.doxygen-content div.fragment {
+	padding: 0 0 1px 0; /*Fixed: last line underline overlap border*/
+	margin: 4px 8px 4px 2px;
+	color: black;
+	background-color: #FBFCFD;
+	border: 1px solid #C4CFE5;
+}
+
+.doxygen-content div.line {
+	font-family: monospace,fixed;
+        font-size: 13px;
+	min-height: 13px;
+	line-height: 1.0;
+	text-wrap: unrestricted;
+	white-space: -moz-pre-wrap; /* Moz */
+	white-space: -pre-wrap;     /* Opera 4-6 */
+	white-space: -o-pre-wrap;   /* Opera 7 */
+	white-space: pre-wrap;      /* CSS3  */
+	word-wrap: break-word;      /* IE 5.5+ */
+	text-indent: -53px;
+	padding-left: 53px;
+	padding-bottom: 0px;
+	margin: 0px;
+	-webkit-transition-property: background-color, box-shadow;
+	-webkit-transition-duration: 0.5s;
+	-moz-transition-property: background-color, box-shadow;
+	-moz-transition-duration: 0.5s;
+	-ms-transition-property: background-color, box-shadow;
+	-ms-transition-duration: 0.5s;
+	-o-transition-property: background-color, box-shadow;
+	-o-transition-duration: 0.5s;
+	transition-property: background-color, box-shadow;
+	transition-duration: 0.5s;
+}
+
+.doxygen-content div.line:after {
+    content:"\A ";
+    white-space: pre;
+}
+
+.doxygen-content div.line.glow {
+	background-color: cyan;
+	box-shadow: 0 0 10px cyan;
+}
+
+
+.doxygen-content span.lineno {
+	padding-right: 4px;
+        margin-right: 9px;
+	text-align: right;
+	border-right: 2px solid #00FF00;
+	color: black;
+	background-color: #E8E8E8;
+        white-space: pre;
+}
+.doxygen-content span.lineno a, .doxygen-content span.lineno a:visited {
+	color: #4665A2;
+	background-color: #D8D8D8;
+}
+
+.doxygen-content span.lineno a:hover {
+	color: #4665A2;
+	background-color: #C8C8C8;
+}
+
+.doxygen-content .lineno {
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.doxygen-content div.classindex ul {
+        list-style: none;
+        padding-left: 0;
+}
+
+.doxygen-content div.classindex span.ai {
+        display: inline-block;
+}
+
+.doxygen-content div.groupHeader {
+	margin-left: 16px;
+	margin-top: 12px;
+	font-weight: bold;
+}
+
+.doxygen-content div.groupText {
+	margin-left: 16px;
+	font-style: italic;
+}
+
+.doxygen-content {
+	color: black;
+        margin: 0;
+}
+
+.doxygen-content div.contents {
+	margin-top: 10px;
+	margin-left: 12px;
+	margin-right: 8px;
+}
+
+.doxygen-content p.formulaDsp {
+	text-align: center;
+}
+
+.doxygen-content img.dark-mode-visible {
+	display: none;
+}
+.doxygen-content img.light-mode-visible {
+	display: none;
+}
+
+.doxygen-content img.formulaDsp {
+	
+}
+
+.doxygen-content img.formulaInl, .doxygen-content img.inline {
+	vertical-align: middle;
+}
+
+.doxygen-content div.center {
+	text-align: center;
+        margin-top: 0px;
+        margin-bottom: 0px;
+        padding: 0px;
+}
+
+.doxygen-content div.center img {
+	border: 0px;
+}
+
+.doxygen-content address.footer {
+	text-align: right;
+	padding-right: 12px;
+}
+
+.doxygen-content img.footer {
+	border: 0px;
+	vertical-align: middle;
+	width: 104px;
+}
+
+.doxygen-content .compoundTemplParams {
+	color: #4665A2;
+	font-size: 80%;
+	line-height: 120%;
+}
+
+/* @group Code Colorization */
+
+.doxygen-content span.keyword {
+	color: #008000;
+}
+
+.doxygen-content span.keywordtype {
+	color: #604020;
+}
+
+.doxygen-content span.keywordflow {
+	color: #E08000;
+}
+
+.doxygen-content span.comment {
+	color: #800000;
+}
+
+.doxygen-content span.preprocessor {
+	color: #806020;
+}
+
+.doxygen-content span.stringliteral {
+	color: #002080;
+}
+
+.doxygen-content span.charliteral {
+	color: #008080;
+}
+
+.doxygen-content span.vhdldigit { 
+	color: #FF00FF;
+}
+
+.doxygen-content span.vhdlchar { 
+	color: #000000;
+}
+
+.doxygen-content span.vhdlkeyword { 
+	color: #700070;
+}
+
+.doxygen-content span.vhdllogic { 
+	color: #FF0000;
+}
+
+.doxygen-content blockquote {
+        background-color: #F7F8FB;
+        border-left: 2px solid #9CAFD4;
+        margin: 0 24px 0 4px;
+        padding: 0 12px 0 16px;
+}
+
+/* @end */
+
+.doxygen-content td.tiny {
+	font-size: 75%;
+}
+
+.doxygen-content .dirtab {
+	padding: 4px;
+	border-collapse: collapse;
+	border: 1px solid #2D4068;
+}
+
+.doxygen-content th.dirtab {
+	background-color: #374F7F;
+	color: #FFFFFF;
+	font-weight: bold;
+}
+
+.doxygen-content hr {
+	height: 0px;
+	border: none;
+	border-top: 1px solid #4A6AAA;
+}
+
+.doxygen-content hr.footer {
+	height: 1px;
+}
+
+/* @group Member Descriptions */
+
+.doxygen-content table.memberdecls {
+	border-spacing: 0px;
+	padding: 0px;
+	overflow: unset;
+	border-collapse: unset;
+	width: unset;
+}
+
+.doxygen-content .memberdecls td, .doxygen-content .fieldtable tr {
+	-webkit-transition-property: background-color, box-shadow;
+	-webkit-transition-duration: 0.5s;
+	-moz-transition-property: background-color, box-shadow;
+	-moz-transition-duration: 0.5s;
+	-ms-transition-property: background-color, box-shadow;
+	-ms-transition-duration: 0.5s;
+	-o-transition-property: background-color, box-shadow;
+	-o-transition-duration: 0.5s;
+	transition-property: background-color, box-shadow;
+	transition-duration: 0.5s;
+}
+
+.doxygen-content .memberdecls td.glow, .doxygen-content .fieldtable tr.glow {
+	background-color: cyan;
+	box-shadow: 0 0 15px cyan;
+}
+
+.doxygen-content .mdescLeft, .doxygen-content .mdescRight,
+.doxygen-content .memItemLeft, .doxygen-content .memItemRight,
+.doxygen-content .memTemplItemLeft, .doxygen-content .memTemplItemRight, .doxygen-content .memTemplParams {
+	background-color: #F9FAFC;
+	border: none;
+	margin: 4px;
+	padding: 1px 0 0 8px;
+}
+
+.doxygen-content .mdescLeft, .doxygen-content .mdescRight {
+	padding: 0px 8px 4px 8px;
+	color: #555;
+}
+
+.doxygen-content .memSeparator {
+        border-bottom: 1px solid #DEE4F0;
+        line-height: 1px;
+        margin: 0px;
+        padding: 0px;
+}
+
+.doxygen-content .memItemLeft, .doxygen-content .memTemplItemLeft {
+        white-space: nowrap;
+}
+
+.doxygen-content .memItemRight, .doxygen-content .memTemplItemRight {
+	width: 100%;
+}
+
+.doxygen-content .memTemplParams {
+	color: #4665A2;
+        white-space: nowrap;
+	font-size: 80%;
+}
+
+/* @end */
+
+/* @group Member Details */
+
+/* Styles for detailed member documentation */
+
+.doxygen-content .memtitle {
+	padding: 8px;
+	border-top: 1px solid #A8B8D9;
+	border-left: 1px solid #A8B8D9;
+	border-right: 1px solid #A8B8D9;
+	border-top-right-radius: 4px;
+	border-top-left-radius: 4px;
+	margin-bottom: -1px;
+	background-image: url("nav_f.png");
+	background-repeat: repeat-x;
+	background-color: #E2E8F2;
+	line-height: 1.25;
+	font-weight: 300;
+	float:left;
+}
+
+.doxygen-content .permalink
+{
+        font-size: 65%;
+        display: inline-block;
+        vertical-align: middle;
+}
+
+.doxygen-content .memtemplate {
+	font-size: 80%;
+	color: #4665A2;
+	font-weight: normal;
+	margin-left: 9px;
+}
+
+.doxygen-content .mempage {
+	width: 100%;
+}
+
+.doxygen-content .memitem {
+	padding: 0;
+	margin-bottom: 10px;
+	margin-right: 5px;
+        -webkit-transition: box-shadow 0.5s linear;
+        -moz-transition: box-shadow 0.5s linear;
+        -ms-transition: box-shadow 0.5s linear;
+        -o-transition: box-shadow 0.5s linear;
+        transition: box-shadow 0.5s linear;
+        display: table !important;
+        width: 100%;
+}
+
+.doxygen-content .memitem.glow {
+         box-shadow: 0 0 15px cyan;
+}
+
+.doxygen-content .memname {
+        font-weight: 400;
+        margin-left: 6px;
+}
+
+.doxygen-content .memname td {
+	vertical-align: bottom;
+}
+
+.doxygen-content .memproto, .doxygen-content dl.reflist dt {
+        border-top: 1px solid #A8B8D9;
+        border-left: 1px solid #A8B8D9;
+        border-right: 1px solid #A8B8D9;
+        padding: 6px 0px 6px 0px;
+        color: #253555;
+        font-weight: bold;
+        text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+        background-color: #DFE5F1;
+        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+        border-top-right-radius: 4px;
+}
+
+.doxygen-content .overload {
+        font-family: monospace,fixed;
+	font-size: 65%;
+}
+
+.doxygen-content .memdoc, .doxygen-content dl.reflist dd {
+        border-bottom: 1px solid #A8B8D9;
+        border-left: 1px solid #A8B8D9;
+        border-right: 1px solid #A8B8D9;
+        padding: 6px 10px 2px 10px;
+        border-top-width: 0;
+        background-image:url("nav_g.png");
+        background-repeat:repeat-x;
+        background-color: white;
+        /* opera specific markup */
+        border-bottom-left-radius: 4px;
+        border-bottom-right-radius: 4px;
+        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+        /* firefox specific markup */
+        -moz-border-radius-bottomleft: 4px;
+        -moz-border-radius-bottomright: 4px;
+        -moz-box-shadow: rgba(0, 0, 0, 0.15) 5px 5px 5px;
+        /* webkit specific markup */
+        -webkit-border-bottom-left-radius: 4px;
+        -webkit-border-bottom-right-radius: 4px;
+        -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+}
+
+.doxygen-content dl.reflist dt {
+        padding: 5px;
+}
+
+.doxygen-content dl.reflist dd {
+        margin: 0px 0px 10px 0px;
+        padding: 5px;
+}
+
+.doxygen-content .paramkey {
+	text-align: right;
+}
+
+.doxygen-content .paramtype {
+	white-space: nowrap;
+}
+
+.doxygen-content .paramname {
+	color: #602020;
+	white-space: nowrap;
+}
+.doxygen-content .paramname em {
+	font-style: normal;
+}
+.doxygen-content .paramname code {
+        line-height: 14px;
+}
+
+.doxygen-content .params, .doxygen-content .retval, .doxygen-content .exception, .doxygen-content .tparams {
+        margin-left: 0px;
+        padding-left: 0px;
+}
+
+.doxygen-content .params .paramname, .doxygen-content .retval .paramname, .doxygen-content .tparams .paramname, .doxygen-content .exception .paramname {
+        font-weight: bold;
+        vertical-align: top;
+}
+
+.doxygen-content .params .paramtype, .doxygen-content .tparams .paramtype {
+        font-style: italic;
+        vertical-align: top;
+}
+
+.doxygen-content .params .paramdir, .doxygen-content .tparams .paramdir {
+        font-family: monospace,fixed;
+        vertical-align: top;
+}
+
+.doxygen-content table.mlabels {
+	border-spacing: 0px;
+}
+
+.doxygen-content td.mlabels-left {
+	width: 100%;
+	padding: 0px;
+}
+
+.doxygen-content td.mlabels-right {
+	vertical-align: bottom;
+	padding: 0px;
+	white-space: nowrap;
+}
+
+.doxygen-content span.mlabels {
+        margin-left: 8px;
+}
+
+.doxygen-content span.mlabel {
+        background-color: #728DC1;
+        border-top:1px solid #5373B4;
+        border-left:1px solid #5373B4;
+        border-right:1px solid #C4CFE5;
+        border-bottom:1px solid #C4CFE5;
+	text-shadow: none;
+	color: white;
+	margin-right: 4px;
+	padding: 2px 3px;
+	border-radius: 3px;
+	font-size: 7pt;
+	white-space: nowrap;
+	vertical-align: middle;
+}
+
+
+
+/* @end */
+
+/* these are for tree view inside a (index) page */
+
+.doxygen-content div.directory {
+        margin: 10px 0px;
+        border-top: 1px solid #9CAFD4;
+        border-bottom: 1px solid #9CAFD4;
+        width: 100%;
+}
+
+.doxygen-content .directory table {
+        border-collapse:collapse;
+}
+
+.doxygen-content .directory td {
+        margin: 0px;
+        padding: 0px;
+	vertical-align: top;
+}
+
+.doxygen-content .directory td.entry {
+        white-space: nowrap;
+        padding-right: 6px;
+	padding-top: 3px;
+}
+
+.doxygen-content .directory td.entry a {
+        outline:none;
+}
+
+.doxygen-content .directory td.entry a img {
+        border: none;
+}
+
+.doxygen-content .directory td.desc {
+        width: 100%;
+        padding-left: 6px;
+	padding-right: 6px;
+	padding-top: 3px;
+	border-left: 1px solid rgba(0,0,0,0.05);
+}
+
+.doxygen-content .directory tr.odd {
+	padding-left: 6px;
+	background-color: #F8F9FC;
+}
+
+.doxygen-content .directory tr.even {
+	padding-left: 6px;
+	background-color: white;
+}
+
+.doxygen-content .directory img {
+	vertical-align: -30%;
+}
+
+.doxygen-content .directory .levels {
+        white-space: nowrap;
+        width: 100%;
+        text-align: right;
+        font-size: 9pt;
+}
+
+.doxygen-content .directory .levels span {
+        cursor: pointer;
+        padding-left: 2px;
+        padding-right: 2px;
+	color: #3D578C;
+}
+
+.doxygen-content .arrow {
+    color: #9CAFD4;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    font-size: 80%;
+    display: inline-block;
+    width: 16px;
+    height: 22px;
+}
+
+.doxygen-content .icon {
+    font-family: Arial,Helvetica;
+    line-height: normal;
+    font-weight: bold;
+    font-size: 12px;
+    height: 14px;
+    width: 16px;
+    display: inline-block;
+    background-color: #728DC1;
+    color: white;
+    text-align: center;
+    border-radius: 4px;
+    margin-left: 2px;
+    margin-right: 2px;
+}
+
+.doxygen-content .icona {
+    width: 24px;
+    height: 22px;
+    display: inline-block;
+}
+
+.doxygen-content .iconfopen {
+    width: 24px;
+    height: 18px;
+    margin-bottom: 4px;
+    background-image:url("folderopen.png");
+    background-position: 0px -4px;
+    background-repeat: repeat-y;
+    vertical-align:top;
+    display: inline-block;
+}
+
+.doxygen-content .iconfclosed {
+    width: 24px;
+    height: 18px;
+    margin-bottom: 4px;
+    background-image:url("folderclosed.png");
+    background-position: 0px -4px;
+    background-repeat: repeat-y;
+    vertical-align:top;
+    display: inline-block;
+}
+
+.doxygen-content .icondoc {
+    width: 24px;
+    height: 18px;
+    margin-bottom: 4px;
+    background-image:url("doc.png");
+    background-position: 0px -4px;
+    background-repeat: repeat-y;
+    vertical-align:top;
+    display: inline-block;
+}
+
+/* @end */
+
+.doxygen-content div.dynheader {
+        margin-top: 8px;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.doxygen-content address {
+	font-style: normal;
+	color: #2A3D61;
+}
+
+.doxygen-content table.doxtable caption {
+	caption-side: top;
+}
+
+.doxygen-content table.doxtable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+.doxygen-content table.doxtable td, .doxygen-content table.doxtable th {
+	border: 1px solid #2D4068;
+	padding: 3px 7px 2px;
+}
+
+.doxygen-content table.doxtable th {
+	background-color: #374F7F;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+.doxygen-content table.fieldtable {
+        margin-bottom: 10px;
+        border: 1px solid #A8B8D9;
+        border-spacing: 0px;
+        border-radius: 4px;
+        box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.15);
+}
+
+.doxygen-content .fieldtable td, .doxygen-content .fieldtable th {
+        padding: 3px 7px 2px;
+}
+
+.doxygen-content .fieldtable td.fieldtype, .doxygen-content .fieldtable td.fieldname {
+        white-space: nowrap;
+        border-right: 1px solid #A8B8D9;
+        border-bottom: 1px solid #A8B8D9;
+        vertical-align: top;
+}
+
+.doxygen-content .fieldtable td.fieldname {
+        padding-top: 3px;
+}
+
+.doxygen-content .fieldtable td.fielddoc {
+        border-bottom: 1px solid #A8B8D9;
+}
+
+.doxygen-content .fieldtable td.fielddoc p:first-child {
+        margin-top: 0px;
+}
+
+.doxygen-content .fieldtable td.fielddoc p:last-child {
+        margin-bottom: 2px;
+}
+
+.doxygen-content .fieldtable tr:last-child td {
+        border-bottom: none;
+}
+
+.doxygen-content .fieldtable th {
+        background-image: url("nav_f.png");
+        background-repeat:repeat-x;
+        background-color: #E2E8F2;
+        font-size: 90%;
+        color: #253555;
+        padding-bottom: 4px;
+        padding-top: 5px;
+        text-align:left;
+        font-weight: 400;
+        border-top-left-radius: 4px;
+        border-top-right-radius: 4px;
+        border-bottom: 1px solid #A8B8D9;
+}
+
+
+.doxygen-content .tabsearch {
+	top: 0px;
+	left: 10px;
+	height: 36px;
+	background-image: url("tab_b.png");
+	z-index: 101;
+	overflow: hidden;
+	font-size: 13px;
+}
+
+.doxygen-content .navpath ul
+{
+	font-size: 11px;
+	background-image: url("tab_b.png");
+	background-repeat:repeat-x;
+	background-position: 0 -5px;
+	height:30px;
+	line-height:30px;
+	color:#283A5D;
+	border:solid 1px #C2CDE4;
+	overflow:hidden;
+	margin:0px;
+	padding:0px;
+}
+
+.doxygen-content .navpath li
+{
+	list-style-type:none;
+	float:left;
+	padding-left:10px;
+	padding-right:15px;
+	background-image:url("bc_s.png");
+	background-repeat:no-repeat;
+	background-position:right;
+	color: #364D7C;
+}
+
+.doxygen-content .navpath li.navelem a
+{
+	height:32px;
+	display:block;
+	text-decoration: none;
+	outline: none;
+	color: #283A5D;
+	font-family: "Lucida Grande",Geneva,Helvetica,Arial,sans-serif;
+	text-shadow: 0px 1px 1px rgba(255, 255, 255, 0.9);
+	text-decoration: none;
+}
+
+.doxygen-content .navpath li.navelem a:hover
+{
+	color: white;
+	text-shadow: 0px 1px 1px rgba(0, 0, 0, 1.0);
+}
+
+.doxygen-content .navpath li.footer
+{
+        list-style-type:none;
+        float:right;
+        padding-left:10px;
+        padding-right:15px;
+        background-image:none;
+        background-repeat:no-repeat;
+        background-position:right;
+        color: #2A3D61;
+        font-size: 8pt;
+}
+
+
+.doxygen-content div.summary
+{
+	float: right;
+	font-size: 8pt;
+	padding-right: 5px;
+	width: 50%;
+	text-align: right;
+}
+
+.doxygen-content div.summary a
+{
+	white-space: nowrap;
+}
+
+.doxygen-content table.classindex
+{
+        margin: 10px;
+        white-space: nowrap;
+        margin-left: 3%;
+        margin-right: 3%;
+        width: 94%;
+        border: 0;
+        border-spacing: 0;
+        padding: 0;
+}
+
+.doxygen-content div.ingroups
+{
+	font-size: 8pt;
+	width: 50%;
+	text-align: left;
+}
+
+.doxygen-content div.ingroups a
+{
+	white-space: nowrap;
+}
+
+.doxygen-content div.header
+{
+        background-image: url("nav_h.png");
+        background-repeat:repeat-x;
+	background-color: #F9FAFC;
+	margin:  0px;
+	border-bottom: 1px solid #C4CFE5;
+}
+
+.doxygen-content div.headertitle
+{
+	display: none;
+}
+
+.doxygen-content .PageDocRTL-title div.headertitle {
+  text-align: right;
+  direction: rtl;
+}
+
+.doxygen-content dl {
+        padding: 0 0 0 0;
+}
+
+/* dl.note, dl.warning, dl.attention, dl.pre, dl.post, dl.invariant, dl.deprecated, dl.todo, dl.test, dl.bug, dl.examples */
+.doxygen-content dl.section {
+	margin-left: 0px;
+	padding-left: 0px;
+}
+
+.doxygen-content dl.note {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #D0C000;
+}
+
+.doxygen-content dl.warning, .doxygen-content dl.attention {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #FF0000;
+}
+
+.doxygen-content dl.pre, .doxygen-content dl.post, .doxygen-content dl.invariant {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #00D000;
+}
+
+.doxygen-content dl.deprecated {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #505050;
+}
+
+.doxygen-content dl.todo {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #00C0E0;
+}
+
+.doxygen-content dl.test {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #3030E0;
+}
+
+.doxygen-content dl.bug {
+  margin-left: -7px;
+  padding-left: 3px;
+  border-left: 4px solid;
+  border-color: #C08050;
+}
+
+.doxygen-content dl.section dd {
+	margin-bottom: 6px;
+}
+
+
+.doxygen-content #projectrow
+{
+	height: 56px;
+}
+
+.doxygen-content #projectlogo
+{
+	text-align: center;
+	vertical-align: bottom;
+	border-collapse: separate;
+}
+ 
+.doxygen-content #projectlogo img
+{ 
+	border: 0px none;
+}
+ 
+.doxygen-content #projectalign
+{
+        vertical-align: middle;
+        padding-left: 0.5em;
+}
+
+.doxygen-content #projectname
+{
+	font-size: 200%;
+	font-family: Tahoma,Arial,sans-serif;
+	margin: 0px;
+	padding: 2px 0px;
+}
+
+.doxygen-content #projectbrief
+{
+	font-size: 90%;
+        font-family: Tahoma,Arial,sans-serif;
+	margin: 0px;
+	padding: 0px;
+}
+
+.doxygen-content #projectnumber
+{
+	font-size: 50%;
+	font-family: 50% Tahoma,Arial,sans-serif;
+	margin: 0px;
+	padding: 0px;
+}
+
+.doxygen-content #titlearea
+{
+	padding: 0px;
+	margin: 0px;
+	width: 100%;
+	border-bottom: 1px solid #5373B4;
+	background-color: white;
+}
+
+.doxygen-content .image
+{
+        text-align: center;
+}
+
+.doxygen-content .dotgraph
+{
+        text-align: center;
+}
+
+.doxygen-content .mscgraph
+{
+        text-align: center;
+}
+
+.doxygen-content .plantumlgraph
+{
+        text-align: center;
+}
+
+.doxygen-content .diagraph
+{
+        text-align: center;
+}
+
+.doxygen-content .caption
+{
+	font-weight: bold;
+}
+
+.doxygen-content dl.citelist {
+        margin-bottom:50px;
+}
+
+.doxygen-content dl.citelist dt {
+        color:#334975;
+        float:left;
+        font-weight:bold;
+        margin-right:10px;
+        padding:5px;
+        text-align:right;
+        width:52px;
+}
+
+.doxygen-content dl.citelist dd {
+        margin:2px 0 2px 72px;
+        padding:5px 0;
+}
+
+.doxygen-content div.toc {
+        padding: 14px 25px;
+        background-color: #F4F6FA;
+        border: 1px solid #D8DFEE;
+        border-radius: 7px 7px 7px 7px;
+        float: right;
+        height: auto;
+        margin: 0 8px 10px 10px;
+        width: 200px;
+}
+
+.doxygen-content div.toc li {
+        background: url("bdwn.png") no-repeat scroll 0 5px transparent;
+        font: 10px/1.2 Verdana,"DejaVu Sans",Geneva,sans-serif;
+        margin-top: 5px;
+        padding-left: 10px;
+        padding-top: 2px;
+}
+
+.doxygen-content div.toc h3 {
+        font: bold 12px/1.2 Verdana,"DejaVu Sans",Geneva,sans-serif;
+	color: #4665A2;
+        border-bottom: 0 none;
+        margin: 0;
+}
+
+.doxygen-content div.toc ul {
+        list-style: none outside none;
+        border: medium none;
+        padding: 0px;
+}
+
+.doxygen-content div.toc li.level1 {
+        margin-left: 0px;
+}
+
+.doxygen-content div.toc li.level2 {
+        margin-left: 15px;
+}
+
+.doxygen-content div.toc li.level3 {
+        margin-left: 30px;
+}
+
+.doxygen-content div.toc li.level4 {
+        margin-left: 45px;
+}
+
+.doxygen-content span.emoji {
+        /* font family used at the site: https://unicode.org/emoji/charts/full-emoji-list.html
+         * font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", Times, Symbola, Aegyptus, Code2000, Code2001, Code2002, Musica, serif, LastResort;
+         */
+}
+
+.doxygen-content span.obfuscator {
+  display: none;
+}
+
+.doxygen-content .inherit_header {
+        font-weight: bold;
+        color: gray;
+        cursor: pointer;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.doxygen-content .inherit_header td {
+        padding: 6px 0px 2px 5px;
+}
+
+.doxygen-content .inherit {
+        display: none;
+}
+
+.doxygen-content tr.heading h2 {
+        margin-top: 12px;
+        margin-bottom: 4px;
+}
+
+/* tooltip related style info */
+
+.doxygen-content .ttc {
+        position: absolute;
+        display: none;
+}
+
+.doxygen-content #powerTip {
+	cursor: default;
+	/*white-space: nowrap;*/
+        color: black;
+	background-color: white;
+	border: 1px solid gray;
+	border-radius: 4px 4px 4px 4px;
+	box-shadow: 1px 1px 7px gray;
+	display: none;
+	font-size: smaller;
+	max-width: 80%;
+	opacity: 0.9;
+	padding: 1ex 1em 1em;
+	position: absolute;
+	z-index: 2147483647;
+}
+
+.doxygen-content #powerTip div.ttdoc {
+        color: grey;
+	font-style: italic;
+}
+
+.doxygen-content #powerTip div.ttname a {
+        font-weight: bold;
+}
+
+.doxygen-content #powerTip a {
+	color: #4665A2;
+}
+
+.doxygen-content #powerTip div.ttname {
+        font-weight: bold;
+}
+
+.doxygen-content #powerTip div.ttdeci {
+        color: #006318;
+}
+
+.doxygen-content #powerTip div {
+        margin: 0px;
+        padding: 0px;
+        font-size: 12px;
+       	font-family: Roboto,sans-serif;
+	line-height: 16px;
+}
+
+.doxygen-content #powerTip:before, .doxygen-content #powerTip:after {
+	content: "";
+	position: absolute;
+	margin: 0px;
+}
+
+.doxygen-content #powerTip.n:after,  .doxygen-content #powerTip.n:before,
+.doxygen-content #powerTip.s:after,  .doxygen-content #powerTip.s:before,
+.doxygen-content #powerTip.w:after,  .doxygen-content #powerTip.w:before,
+.doxygen-content #powerTip.e:after,  .doxygen-content #powerTip.e:before,
+.doxygen-content #powerTip.ne:after, .doxygen-content #powerTip.ne:before,
+.doxygen-content #powerTip.se:after, .doxygen-content #powerTip.se:before,
+.doxygen-content #powerTip.nw:after, .doxygen-content #powerTip.nw:before,
+.doxygen-content #powerTip.sw:after, .doxygen-content #powerTip.sw:before {
+	border: solid transparent;
+	content: " ";
+	height: 0;
+	width: 0;
+	position: absolute;
+}
+
+.doxygen-content #powerTip.n:after,  .doxygen-content #powerTip.s:after,
+.doxygen-content #powerTip.w:after,  .doxygen-content #powerTip.e:after,
+.doxygen-content #powerTip.nw:after, .doxygen-content #powerTip.ne:after,
+.doxygen-content #powerTip.sw:after, .doxygen-content #powerTip.se:after {
+	border-color: rgba(255, 255, 255, 0);
+}
+
+.doxygen-content #powerTip.n:before,  .doxygen-content #powerTip.s:before,
+.doxygen-content #powerTip.w:before,  .doxygen-content #powerTip.e:before,
+.doxygen-content #powerTip.nw:before, .doxygen-content #powerTip.ne:before,
+.doxygen-content #powerTip.sw:before, .doxygen-content #powerTip.se:before {
+	border-color: rgba(128, 128, 128, 0);
+}
+
+.doxygen-content #powerTip.n:after,  .doxygen-content #powerTip.n:before,
+.doxygen-content #powerTip.ne:after, .doxygen-content #powerTip.ne:before,
+.doxygen-content #powerTip.nw:after, .doxygen-content #powerTip.nw:before {
+	top: 100%;
+}
+
+.doxygen-content #powerTip.n:after, .doxygen-content #powerTip.ne:after, .doxygen-content #powerTip.nw:after {
+	border-top-color: white;
+	border-width: 10px;
+	margin: 0px -10px;
+}
+.doxygen-content #powerTip.n:before, .doxygen-content #powerTip.ne:before, .doxygen-content #powerTip.nw:before {
+	border-top-color: gray;
+	border-width: 11px;
+	margin: 0px -11px;
+}
+.doxygen-content #powerTip.n:after, .doxygen-content #powerTip.n:before {
+	left: 50%;
+}
+
+.doxygen-content #powerTip.nw:after, .doxygen-content #powerTip.nw:before {
+	right: 14px;
+}
+
+.doxygen-content #powerTip.ne:after, .doxygen-content #powerTip.ne:before {
+	left: 14px;
+}
+
+.doxygen-content #powerTip.s:after,  .doxygen-content #powerTip.s:before,
+.doxygen-content #powerTip.se:after, .doxygen-content #powerTip.se:before,
+.doxygen-content #powerTip.sw:after, .doxygen-content #powerTip.sw:before {
+	bottom: 100%;
+}
+
+.doxygen-content #powerTip.s:after, .doxygen-content #powerTip.se:after, .doxygen-content #powerTip.sw:after {
+	border-bottom-color: white;
+	border-width: 10px;
+	margin: 0px -10px;
+}
+
+.doxygen-content #powerTip.s:before, .doxygen-content #powerTip.se:before, .doxygen-content #powerTip.sw:before {
+	border-bottom-color: gray;
+	border-width: 11px;
+	margin: 0px -11px;
+}
+
+.doxygen-content #powerTip.s:after, .doxygen-content #powerTip.s:before {
+	left: 50%;
+}
+
+.doxygen-content #powerTip.sw:after, .doxygen-content #powerTip.sw:before {
+	right: 14px;
+}
+
+.doxygen-content #powerTip.se:after, .doxygen-content #powerTip.se:before {
+	left: 14px;
+}
+
+.doxygen-content #powerTip.e:after, .doxygen-content #powerTip.e:before {
+	left: 100%;
+}
+.doxygen-content #powerTip.e:after {
+	border-left-color: gray;
+	border-width: 10px;
+	top: 50%;
+	margin-top: -10px;
+}
+.doxygen-content #powerTip.e:before {
+	border-left-color: gray;
+	border-width: 11px;
+	top: 50%;
+	margin-top: -11px;
+}
+
+.doxygen-content #powerTip.w:after, .doxygen-content #powerTip.w:before {
+	right: 100%;
+}
+.doxygen-content #powerTip.w:after {
+	border-right-color: gray;
+	border-width: 10px;
+	top: 50%;
+	margin-top: -10px;
+}
+.doxygen-content #powerTip.w:before {
+	border-right-color: gray;
+	border-width: 11px;
+	top: 50%;
+	margin-top: -11px;
+}
+
+@media print
+{
+  .doxygen-content #top { display: none; }
+  .doxygen-content #side-nav { display: none; }
+  .doxygen-content #nav-path { display: none; }
+  .doxygen-content { overflow:visible; }
+  .doxygen-content h1, .doxygen-content h2, .doxygen-content h3, .doxygen-content h4, .doxygen-content h5, .doxygen-content h6 { page-break-after: avoid; }
+  .doxygen-content .summary { display: none; }
+  .doxygen-content .memitem { page-break-inside: avoid; }
+  .doxygen-content #doc-content
+  {
+    margin-left:0 !important;
+    height:auto !important;
+    width:auto !important;
+    overflow:inherit;
+    display:inline;
+  }
+}
+
+/* @group Markdown */
+
+.doxygen-content table.markdownTable {
+	border-collapse:collapse;
+        margin-top: 4px;
+        margin-bottom: 4px;
+}
+
+.doxygen-content table.markdownTable td, .doxygen-content table.markdownTable th {
+	border: 1px solid #2D4068;
+	padding: 3px 7px 2px;
+}
+
+.doxygen-content table.markdownTable tr {
+}
+
+.doxygen-content th.markdownTableHeadLeft, .doxygen-content th.markdownTableHeadRight, .doxygen-content th.markdownTableHeadCenter, .doxygen-content th.markdownTableHeadNone {
+	background-color: #374F7F;
+	color: #FFFFFF;
+	font-size: 110%;
+	padding-bottom: 4px;
+	padding-top: 5px;
+}
+
+.doxygen-content th.markdownTableHeadLeft, .doxygen-content td.markdownTableBodyLeft {
+	text-align: left
+}
+
+.doxygen-content th.markdownTableHeadRight, .doxygen-content td.markdownTableBodyRight {
+	text-align: right
+}
+
+.doxygen-content th.markdownTableHeadCenter, .doxygen-content td.markdownTableBodyCenter {
+	text-align: center
+}
+
+.doxygen-content tt, .doxygen-content code, .doxygen-content kbd, .doxygen-content samp
+{
+  display: inline-block;
+}
+/* @end */
+
+.doxygen-content u {
+	text-decoration: underline;
+}
+
+.doxygen-content details>summary {
+  list-style-type: none;
+}
+
+.doxygen-content details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.doxygen-content details>summary::before {
+    content: "►";
+    padding-right:4px;
+    font-size: 80%;
+}
+
+.doxygen-content details[open]>summary::before {
+    content: "▼";
+    padding-right:4px;
+    font-size: 80%;
+}
+
+.doxygen-content .contents .doxysphinx-inline-parent p {
+	display: inline;
+}


### PR DESCRIPTION
Style the doxysphinx generated pages using [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css)
modified by integrating into the sphinx-book-theme's dark/light themes.

The doxygen header/footer and the the stylesheets are copied in with rocm-docs-core, projects need to set the path to them in their Doxyfile to use these themes.

This also removes the need for sass (and node.js) to be installed as the stylesheets are installed in their already processed form.

Stacked upon #32, it should be merged first.