### PR TITLE
Make fonts scale to different screen sizes

### DIFF
--- a/src/rocm_docs/data/_static/custom.css
+++ b/src/rocm_docs/data/_static/custom.css
@@ -1,7 +1,19 @@
 @import url("theme.css");
 
 :root {
-    --pst-font-size-base: 0.75rem;
+    --pst-font-size-base: 1.25rem;
+}
+
+@media screen and (min-width: 1000px) {
+    :root {
+        --pst-font-size-base: 0.5rem;
+    }
+}
+
+@media screen and (min-width: 2000px) {
+    :root {
+        --pst-font-size-base: 0.75rem;
+    }
 }
 
 div#site-navigation {

--- a/src/rocm_docs/data/_static/custom.css
+++ b/src/rocm_docs/data/_static/custom.css
@@ -1,18 +1,18 @@
 @import url("theme.css");
 
 :root {
-    --pst-font-size-base: 1.25rem;
+    --pst-font-size-base: 0.5rem;
 }
 
 @media screen and (min-width: 1000px) {
     :root {
-        --pst-font-size-base: 0.5rem;
+        --pst-font-size-base: 0.75rem;
     }
 }
 
 @media screen and (min-width: 2000px) {
     :root {
-        --pst-font-size-base: 0.75rem;
+        --pst-font-size-base: 1.25rem;
     }
 }
 

--- a/src/rocm_docs/data/_static/rocm_header.css
+++ b/src/rocm_docs/data/_static/rocm_header.css
@@ -23,8 +23,9 @@
 }
 
 .rocm-header img#amd-logo{
-    margin: 1em;
-    width: 8.25rem;
+    width: auto;
+    height: auto;
+    max-height: 2rem;
 }
 
 .rocm-header img#rocm-logo{


### PR DESCRIPTION
Fonts scale to different screen sizes

Screen Width: Font Size relative to root element
less than 1000px: 0.5x 
1000px-2000px: 0.75x
greater than 2000px: 1.25x

Also, ensure the ROCm logo doesn't distort or overextend the header