### PR TITLE
Various stlysheet fixes

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -1,10 +1,8 @@
-@import url("theme.css");
-
 :root {
-    --pst-font-size-base: 0.5rem;
+    --pst-font-size-base: 0.625rem;
 }
 
-@media screen and (min-width: 1000px) {
+@media screen and (min-width: 440px) {
     :root {
         --pst-font-size-base: 0.75rem;
     }

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
@@ -10,7 +10,7 @@
     width: 100%;
     padding-top: 5px;
     line-height: 20px;
-    height: 120px;
+    min-height: 120px;
 }
 
 .rocm-footer a, .rocm-footer p {


### PR DESCRIPTION
- Lower small font-size threshold until its absolutely required for
  fitting the content on screen, and make it slightly bigger in that case.
  This allows to keep the normal font-size when e.g. splitting the
  screen on a normal laptop.
- Remove the import of `theme.css` as custom.css is applied as an *extra*
  stylesheet therefore its already part of the style.
- Change the rocm-footers height to be min-height instead, so its content
  does not overflow it, when it needs to display more rows (on narrow
  devices).

~~Stacked on top of #41, to avoid conflicts.~~ Merged