### PR TITLE
Stop generating watermark on docs

### DIFF
--- a/src/rocm_docs/data/_templates/sections/footer.html
+++ b/src/rocm_docs/data/_templates/sections/footer.html
@@ -17,7 +17,3 @@
         </ul>
     </div>
 </div>
-
-<div id="rdc-watermark-container">
-    <img id="rdc-watermark" src="{{ pathto('rdc-watermark.svg',1) }}" alt="DRAFT watermark"/>
-</div>


### PR DESCRIPTION
Removes the reference to the watermark image source in the footer.

Kept the SVG and CSS in case we want to add back watermarks.