### PR TITLE
Auto release fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ on:
     secrets:
       PYPI_TOKEN:
         required: true
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -1,9 +1,9 @@
-name: "Merge to develop"
+name: "Sync to develop"
 
 on:
   workflow_call:
     inputs:
-      revision:
+      sha:
         required: true
         type: string
   workflow_dispatch:
@@ -12,12 +12,17 @@ jobs:
   sync_branches:
     runs-on: ubuntu-latest
     concurrency: sync_branches
-    name: Merge a branch into the default branch (develop)
+    name: Sync the branch with the default branch (develop)
     steps:
-    - name: Merge branch -> default
-      uses: devmasx/merge-branch@1.4.0
-      with:
-        type: now
-        head_to_merge: ${{ inputs.revision || github.sha }}
-        target_branch: ${{ github.event.repository.default_branch }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Push develop forward (ff only)
+      shell: sh
+      run: |
+        REF="refs/heads/${{ github.event.repository.default_branch }}"
+        gh api "/repos/${{ github.repository }}/git/$REF"   \
+          --method PATCH                                    \
+          --header "Accept: application/vnd.github+json"    \
+          --header "X-GitHub-Api-Version: 2022-11-28"       \
+          --raw-field sha='${{ inputs.sha || github.sha }}' \
+          --field force=false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -1,0 +1,23 @@
+name: "Merge to develop"
+
+on:
+  workflow_call:
+    inputs:
+      revision:
+        required: true
+        type: string
+  workflow_dispatch:
+
+jobs:
+  sync_branches:
+    runs-on: ubuntu-latest
+    concurrency: sync_branches
+    name: Merge a branch into the default branch (develop)
+    steps:
+    - name: Merge branch -> default
+      uses: devmasx/merge-branch@1.4.0
+      with:
+        type: now
+        head_to_merge: ${{ inputs.revision || github.sha }}
+        target_branch: ${{ github.event.repository.default_branch }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   bump-version:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -82,3 +82,11 @@ jobs:
       revision: ${{ needs.bump-version.outputs.revision }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+  call-sync-branches:
+    name: Trigger merge
+    needs: [bump-version]
+    if: needs.bump-version.outputs.bumped == 'true'
+    uses: ./.github/workflows/sync_branches.yml
+    with:
+      revision: ${{ needs.bump-version.outputs.revision }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       bumped: ${{ steps.cz-bump.outputs.bumped }}
       revision: ${{ steps.cz-bump.outputs.revision }}
+      sha: ${{ steps.cz-bump.outputs.sha }}
     steps:
       - uses: actions/checkout@v3.5.0
         with:
@@ -54,6 +55,7 @@ jobs:
           if [ "$RESULT" -eq 0 ]; then
             echo "bumped=true" >> "$GITHUB_OUTPUT"
             echo "revision=v$(cz version --project)" >> "$GITHUB_OUTPUT"
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           # https://commitizen-tools.github.io/commitizen/exit_codes/
           # NoneIncrementExit(21): No need to increment the version number
           elif [ "$RESULT" -eq 21 ]; then
@@ -90,4 +92,4 @@ jobs:
     if: needs.bump-version.outputs.bumped == 'true'
     uses: ./.github/workflows/sync_branches.yml
     with:
-      revision: ${{ needs.bump-version.outputs.revision }}
+      sha: ${{ needs.bump-version.outputs.sha }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -78,6 +78,6 @@ jobs:
     if: needs.bump-version.outputs.bumped == 'true'
     uses: ./.github/workflows/release.yml
     with:
-      revision: ${{ needs.bump-version.revision }}
+      revision: ${{ needs.bump-version.outputs.revision }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -65,7 +65,8 @@ jobs:
         if: steps.cz-bump.outputs.bumped == 'true'
         shell: sh
         run: |
-          git push origin "HEAD:${{ github.ref }}" "${{ steps.cz-bump.outputs.revision }}"
+          git push --atomic origin "HEAD:${{ github.ref }}" \
+            "${{ steps.cz-bump.outputs.revision }}"
       - name: Release
         if: steps.cz-bump.outputs.bumped == 'true'
         uses: softprops/action-gh-release@v0.1.15


### PR DESCRIPTION
- Fix the release pipeline by using the correct variable
- allow running all of the release pipelines manually to aid debugging
- add a pipeline to ~~merge~~ fast-forward the branch it is running on into develop, can be triggered by hand. It is also run as a part of the release process.
- prevent partial pushes for the bump commit by using the `--atomic` option to `git push`

See ~~https://github.com/StreamHPC/rocm-docs-core/actions/runs/4680331546~~ https://github.com/StreamHPC/rocm-docs-core/actions/runs/4686889321 for how a complete run of this pipeline looks like (the push job is failing in the fork because it doesn't have access to pypi which is expected) .