### PR TITLE
Reland css fixes

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -1,10 +1,8 @@
-@import url("theme.css");
-
 :root {
-    --pst-font-size-base: 0.5rem;
+    --pst-font-size-base: 0.625rem;
 }
 
-@media screen and (min-width: 1000px) {
+@media screen and (min-width: 440px) {
     :root {
         --pst-font-size-base: 0.75rem;
     }

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_footer.css
@@ -10,7 +10,7 @@
     width: 100%;
     padding-top: 5px;
     line-height: 20px;
-    height: 120px;
+    min-height: 120px;
 }
 
 .rocm-footer a, .rocm-footer p {


### PR DESCRIPTION
The CSS fixes were lost during the restoration of main, this is the same commit as in #46 rebased, to apply them again in develop.