### PR TITLE
Fix theme on rtd

### DIFF
--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -17,6 +17,7 @@ class ROCmDocs:
     SPHINX_VARS = [
         "extensions",
         "html_title",
+        "html_theme",
         "html_theme_options",
         "doxygen_root",
         "doxygen_project",
@@ -32,6 +33,7 @@ class ROCmDocs:
         self._project_name = project_name
         self.extensions: List[str] = []
         self.html_title: str
+        self.html_theme: str
         self.html_theme_options: Dict[str, Union[str, bool, List[str]]] = {}
         self.doxygen_root: MaybePath
         self.doxygen_project: Tuple[Optional[str], MaybePath]
@@ -70,6 +72,7 @@ class ROCmDocs:
         """Sets up default RTD variables and copies necessary files."""
         self.extensions.append("rocm_docs")
         self.html_title = self._project_name
+        self.html_theme = "rocm_docs_theme"
 
     def disable_main_doc_link(self):
         self.html_theme_options["link_main_doc"] = False

--- a/src/rocm_docs/core.py
+++ b/src/rocm_docs/core.py
@@ -74,7 +74,6 @@ class _DefaultSettings:
     # pylint: disable=redefined-builtin
     copyright = _ConfigDefault("2022-2023, Advanced Micro Devices Ltd")
     # pylint: enable=redefined-builtin
-    html_theme = _ConfigDefault("rocm_docs_theme")
     myst_enable_extensions = _ConfigExtend(
         ["colon_fence", "fieldlist", "linkify", "replacements"]
     )


### PR DESCRIPTION
- #88 results in the sphinx-rtd-theme being used when built using read-the-docs, restore the customized theme by forcing in the legacy api
- change the new extension api to NOT set `html_theme` by default.
  - this is the only sane option that still allows the user to override the setting, because there's no way to distinguish if it was overriden by RTD or the user  
  - it is also more explicit, and makes local and RTD builds be more consistent (they will both apply a "default" theme if none is specified the sphinx default and the rtd default respectively)
  - This is a breaking change for hypotethical users of the new extension interface; fortunately there are none as all current projects still use the legacy (importing `rocm_docs` and using `rocm_docs.setup()`) way of rocm-docs-core :) 