### PR TITLE
ci(release): keep major version at zero

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,4 @@ version = "0.3.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 annotated_tag = true
+major_version_zero = true


### PR DESCRIPTION
set commitizen's `major_version_zero` option to not advance the project to 1.0.0 upon a breaking change [1].

[1]: https://commitizen-tools.github.io/commitizen/bump/#-major-version-zero

@saadrahim, @lawruble13 if you want to do a merge to main (i.e. trigger a release) please get this in first, as I just realized this setting needed to be set, and I don't think we want to go to 1.0.0 just yet.