### PR TITLE
Add version numbers to generated documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-          # Prefix all commit messages with "build: "
-	        prefix: "build(deps)"
+      # Prefix all commit messages with "build: "
+      prefix: "build(deps)"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 
 from rocm_docs import ROCmDocs
 
-docs_core = ROCmDocs("ROCm Docs Core 0.0.2")
+docs_core = ROCmDocs("ROCm Docs Core", "0.4.0")
 docs_core.run_doxygen(doxygen_root="demo/doxygen", doxygen_path=".")
 docs_core.enable_api_reference()
 docs_core.setup()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 
 from rocm_docs import ROCmDocs
 
-docs_core = ROCmDocs("ROCm Docs Core", "0.4.0")
+docs_core = ROCmDocs("ROCm Docs Core")
 docs_core.run_doxygen(doxygen_root="demo/doxygen", doxygen_path=".")
 docs_core.enable_api_reference()
 docs_core.setup()

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -1,5 +1,6 @@
 """Set up variables for documentation of ROCm projects using RTD."""
 import os
+import subprocess
 from pathlib import Path
 from typing import BinaryIO, Dict, Generator, List, Optional, Union
 
@@ -28,9 +29,11 @@ class ROCmDocs:
     def __init__(
         self,
         project_name: str,
+        version_string : str = None,
         _: MaybePath = None,
     ) -> None:
         self._project_name = project_name
+        self._version_string = version_string
         self.extensions: List[str] = []
         self.html_title: str
         self.html_theme: str
@@ -74,7 +77,13 @@ class ROCmDocs:
     def setup(self) -> None:
         """Sets up default RTD variables and copies necessary files."""
         self.extensions.append("rocm_docs")
-        self.html_title = self._project_name
+        full_project_name = self._project_name
+        if self._version_string is None and os.path.exists("../CMakeLists.txt"):
+            getVersionString = r'sed -n -e "s/^.*VERSION_STRING.* \"\([0-9\.]\{1,\}\).*/\1/p" ../CMakeLists.txt'
+            self._version_string = subprocess.getoutput(getVersionString)
+        if self._version_string is not None and len(self._version_string) > 0:
+            full_project_name += f" {self._version_string}"
+        self.html_title = full_project_name
         self.html_theme = "rocm_docs_theme"
 
     def disable_main_doc_link(self):


### PR DESCRIPTION
closes #22 

Grabs VERSION_STRING from CMakeLists.txt if it has it. Also has option to pass in version argument to override.

examples:

`docs_core = ROCmDocs("ROCm Documentation")` > ROCm Documentation (no version arg or VERSION_STRING)

`docs_core = ROCmDocs("ROCm Documentation", "5.6.0 Alpha")` > ROCm Documentation 5.6.0 Alpha (using version arg)

`docs_core = ROCmDocs("hipBLAS Documentation")` > hipBLAS Documentation 1.1.0 (using VERSION_STRING)

`docs_core = ROCmDocs("hipBLAS Documentation", "2.0")` > hipBLAS Documentation 2.0 (using version arg
