### PR TITLE
ci(rtd): Try to restore pinning by changing installation order

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,11 +10,11 @@ formats: [htmlzip]
 
 python:
    install:
-   - requirements: requirements.txt
    - method: pip
      path: .
      extra_requirements:
        - "api_reference"
+   - requirements: requirements.txt
 
 build:
    os: ubuntu-20.04


### PR DESCRIPTION
Seems like read-the-docs is updating the dependencies of rocm-docs-core when it installs it basically destroying our pinning of packages in `requirements.txt`.
With the changed order `requirements.txt` takes priority and downgrades packages that have been upgraded in the previous step, and things seem to work out.

This still leaves the issue of `doxysphinx` 3.3.0 failing, but that can be tackled later.