### PR TITLE
ci: add to wordlist

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -129,6 +129,7 @@ numref
 NVPTX
 OAM
 OAMs
+OEM
 OCP
 OMP
 OMPT


### PR DESCRIPTION
Add Original equipment manufacturer or OEM to wordlist, @Naraenda is there a way to set a lower limit on word length to check? Three letter acronyms are going to get kind of frustrating otherwise I think.