### PR TITLE
Ignore spelling "mistakes" for words under 3 characters

### DIFF
--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -4,6 +4,7 @@ matrix:
   - 'docs/**/*.md'
   aspell:
     lang: en
+    ignore: 3
   dictionary:
     wordlists:
     - .wordlist.txt


### PR DESCRIPTION
Configures PySpelling/ASpell to ignore words that are 3 characters or less.