### PR TITLE
Article-info example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/**/*
 **/*.egg-info/**/*
 .sass-cache/*
 /build
+/_readthedocs/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ dist/**/*
 **/*.egg-info/**/*
 .sass-cache/*
 /build
-/_readthedocs/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,14 +8,15 @@ from rocm_docs import ROCmDocs
 
 html_output_directory = "../_readthedocs/html"
 setting_all_article_info = True
-all_article_info_os = ["linux", "windows"]
-all_article_info_author = ""
-all_article_info_date = "2023"
-all_article_info_read_time = "5-10 min read"
+#all_article_info_os = ["linux", "windows"] # same as default
+#all_article_info_author = "" # same as default
+#all_article_info_date = "2023" # defaults to today
+#all_article_info_read_time = "" # same as default
 
+# specific settings override general settings above
 article_pages = [
     {"file":"index", "os":["windows"], "author":"Author: AMD", "date":"May 1, 2023", "read-time":"2 min read"},
-    {"file":"developer_guide/commitizen", "os":["linux"], "date":"May 1, 2023", "read-time":"10 min read"}
+    {"file":"developer_guide/commitizen"}
 ]
 
 docs_core = ROCmDocs("ROCm Docs Core")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,14 +8,16 @@ from rocm_docs import ROCmDocs
 
 html_output_directory = "../_readthedocs/html"
 setting_all_article_info = True
-#all_article_info_os = ["linux", "windows"] # same as default
-#all_article_info_author = "" # same as default
-#all_article_info_date = "2023" # defaults to today
-#all_article_info_read_time = "" # same as default
 
-# specific settings override general settings above
+# specific settings override any general settings (eg: all_article_info_<field>)
 article_pages = [
-    {"file":"index", "os":["windows"], "author":"Author: AMD", "date":"May 1, 2023", "read-time":"2 min read"},
+    {
+        "file":"index", 
+        "os":["linux", "windows"], 
+        "author":"Author: AMD", 
+        "date":"2023-05-01", 
+        "read-time":"2 min read"
+    },
     {"file":"developer_guide/commitizen"}
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,18 @@
 
 from rocm_docs import ROCmDocs
 
+html_output_directory = "../_readthedocs/html"
+setting_all_article_info = True
+all_article_info_os = ["linux", "windows"]
+all_article_info_author = ""
+all_article_info_date = "2023"
+all_article_info_read_time = "5-10 min read"
+
+article_pages = [
+    {"file":"index", "os":["windows"], "author":"Author: AMD", "date":"May 1, 2023", "read-time":"2 min read"},
+    {"file":"developer_guide/commitizen", "os":["linux"], "date":"May 1, 2023", "read-time":"10 min read"}
+]
+
 docs_core = ROCmDocs("ROCm Docs Core")
 docs_core.run_doxygen(doxygen_root="demo/doxygen", doxygen_path=".")
 docs_core.enable_api_reference()

--- a/src/rocm_docs/core.py
+++ b/src/rocm_docs/core.py
@@ -9,8 +9,9 @@ import types
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Callable, Dict, Generic, List, Type, TypeVar
-from bs4 import BeautifulSoup
+import importlib_resources
 
+from bs4 import BeautifulSoup
 from pydata_sphinx_theme.utils import config_provided_by_user
 from sphinx.application import Sphinx
 from sphinx.config import Config
@@ -144,7 +145,9 @@ def _set_article_info(app: Sphinx, _: Config) -> None:
     if app.config.setting_all_article_info is False and len(app.config.article_pages) == 0:
         return
 
-    with open("_templates/components/article-info.html", "r") as file:
+    rocm_docs_package = importlib_resources.files("rocm_docs")
+    article_info_path = os.path.join(rocm_docs_package, "rocm_docs_theme/components/article-info.html")
+    with open(article_info_path, "r") as file:
         article_info = file.read()
 
     specific_pages = []

--- a/src/rocm_docs/rocm_docs_theme/components/article-info.html
+++ b/src/rocm_docs/rocm_docs_theme/components/article-info.html
@@ -1,7 +1,7 @@
 <div class="sd-container-fluid sd-sphinx-override sd-p-0 sd-mt-2 sd-mb-4 sd-p-2 sd-outline-muted sd-rounded-1 docutils">
 <div class="sd-row sd-row-cols-2 sd-gx-2 sd-gy-1 docutils">
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
-    OS:<!--fontawesome-->
+    OS: <!--osicons-->
 </div>
 <div class="sd-col sd-d-flex-row sd-align-minor-center docutils">
 <div class="sd-container-fluid sd-sphinx-override docutils">

--- a/src/rocm_docs/rocm_docs_theme/components/article-info.html
+++ b/src/rocm_docs/rocm_docs_theme/components/article-info.html
@@ -1,19 +1,19 @@
-<div class="sd-container-fluid sd-sphinx-override sd-p-0 sd-mt-2 sd-mb-4 sd-p-2 sd-outline-muted sd-rounded-1 docutils">
+<div class="sd-container-fluid sd-sphinx-override sd-p-0 sd-mt-2 sd-mb-4 sd-p-2 sd-rounded-1 docutils">
 <div class="sd-row sd-row-cols-2 sd-gx-2 sd-gy-1 docutils">
-<div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
+<div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils" style="color:gray;">
     OS: <!--osicons-->
 </div>
 <div class="sd-col sd-d-flex-row sd-align-minor-center docutils">
 <div class="sd-container-fluid sd-sphinx-override docutils">
 <div class="sd-row sd-row-cols-2 sd-row-cols-xs-2 sd-row-cols-sm-3 sd-row-cols-md-3 sd-row-cols-lg-3 sd-gx-3 sd-gy-1 docutils">
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
-    <p class="sd-p-0 sd-m-0">AMD</p>
+    <p class="sd-p-0 sd-m-0" style="color:gray;">AMD</p>
 </div>
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
-<p class="sd-p-0 sd-m-0"><span class="sd-pr-2"><svg version="1.1" width="16.0px" height="16.0px" class="sd-octicon sd-octicon-calendar" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M4.75 0a.75.75 0 01.75.75V2h5V.75a.75.75 0 011.5 0V2h1.25c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V3.75C1 2.784 1.784 2 2.75 2H4V.75A.75.75 0 014.75 0zm0 3.5h8.5a.25.25 0 01.25.25V6h-11V3.75a.25.25 0 01.25-.25h2zm-2.25 4v6.75c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V7.5h-11z"></path></svg></span>2023</p>
+<p class="sd-p-0 sd-m-0" style="color:gray;"><span class="sd-pr-2"><svg version="1.1" width="16.0px" height="16.0px" class="sd-octicon sd-octicon-calendar" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M4.75 0a.75.75 0 01.75.75V2h5V.75a.75.75 0 011.5 0V2h1.25c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0113.25 16H2.75A1.75 1.75 0 011 14.25V3.75C1 2.784 1.784 2 2.75 2H4V.75A.75.75 0 014.75 0zm0 3.5h8.5a.25.25 0 01.25.25V6h-11V3.75a.25.25 0 01.25-.25h2zm-2.25 4v6.75c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25V7.5h-11z"></path></svg></span>2023</p>
 </div>
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
-<p class="sd-p-0 sd-m-0"><span class="sd-pr-2"><svg version="1.1" width="16.0px" height="16.0px" class="sd-octicon sd-octicon-clock" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zm.5 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 00.471.696l2.5 1a.75.75 0 00.557-1.392L8.5 7.742V4.75z"></path></svg></span>5 min read</p>
+<p class="sd-p-0 sd-m-0" style="color:gray;"><span class="sd-pr-2"><svg version="1.1" width="16.0px" height="16.0px" class="sd-octicon sd-octicon-clock" viewBox="0 0 16 16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zm.5 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 00.471.696l2.5 1a.75.75 0 00.557-1.392L8.5 7.742V4.75z"></path></svg></span>5 min read</p>
 </div>
 </div>
 </div>

--- a/src/rocm_docs/rocm_docs_theme/components/article-info.html
+++ b/src/rocm_docs/rocm_docs_theme/components/article-info.html
@@ -1,7 +1,7 @@
 <div class="sd-container-fluid sd-sphinx-override sd-p-0 sd-mt-2 sd-mb-4 sd-p-2 sd-outline-muted sd-rounded-1 docutils">
 <div class="sd-row sd-row-cols-2 sd-gx-2 sd-gy-1 docutils">
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils">
-    OS: <!--fontawesome-->
+    OS:<!--fontawesome-->
 </div>
 <div class="sd-col sd-d-flex-row sd-align-minor-center docutils">
 <div class="sd-container-fluid sd-sphinx-override docutils">

--- a/src/rocm_docs/rocm_docs_theme/components/left-side-menu.html
+++ b/src/rocm_docs/rocm_docs_theme/components/left-side-menu.html
@@ -1,3 +1,3 @@
-<a class="navbar-brand logo" href="https://rocmdocs.amd.com/projects/alpha/en/develop/">
+<a class="navbar-brand logo" href="https://rocm.docs.amd.com/en/latest/">
     <p>ROCm Docs 5.6.0 Alpha</p>
 </a>

--- a/src/rocm_docs/rocm_docs_theme/sections/footer.html
+++ b/src/rocm_docs/rocm_docs_theme/sections/footer.html
@@ -3,7 +3,7 @@
     <div class="rocm-footer-links">
         <ul>
             <li><a href="https://www.amd.com/en/corporate/copyright" target="_blank">Terms and Conditions</a></li>
-            <li><a href="https://rocmdocs.amd.com/projects/alpha/en/develop/release/licensing.html">ROCm Licenses and Disclaimers</a></li>
+            <li><a href="https://rocm.docs.amd.com/en/latest/release/licensing.html">ROCm Licenses and Disclaimers</a></li>
             <li><a href="https://www.amd.com/en/corporate/privacy" target="_blank">Privacy</a></li>
             <li><a href="https://www.amd.com/en/corporate/trademarks" target="_blank">Trademarks</a></li>
             <li><a href="https://www.amd.com/system/files/documents/statement-human-trafficking-forced-labor.pdf" target="_blank">Statement on Forced Labor</a></li>


### PR DESCRIPTION
@Maetveis @lawruble13 

> Example: https://advanced-micro-devices-demo--139.com.readthedocs.build/projects/rocm-docs-core/en/139/index.html

[Use default values if not specified](https://github.com/RadeonOpenCompute/rocm-docs-core/pull/139/commits/69c5b952bd3f33d1f243a542e8df6ab3e136b314):

- set default os to linux and windows
- auto set date to time the source page was last modified on git
    - closes https://github.com/RadeonOpenCompute/rocm-docs-core/issues/143
- set auto read time (using 200wpm, word len 5 chars) 
    - closes https://github.com/RadeonOpenCompute/rocm-docs-core/issues/142
