### PR TITLE
ci(spellcheck): Ignore out of line links in spellcheck, add some new words

### DIFF
--- a/.spellcheck.yaml
+++ b/.spellcheck.yaml
@@ -19,6 +19,13 @@ matrix:
       - open : '\[[^]]*?]\('
         content: '[^)]*?'
         close: '\)'
+      # Ignore out-of-line URL references in [text][reference-name]
+      - open : '\[[^\]]*?\]\['
+        content: '[^\]]*?'
+        close: '\]'
+      # Ignore out-of-line URL definitions
+      - open : '^ {0,3}\[[^\]]*?\]:\s*\S+'
+        close: '$'
       # Ignore URLs in <URL>
       - open : '\<'
         content: '[^]]*?'

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -131,6 +131,8 @@ MIOpen
 MIVisionX
 MNIST
 MyST
+namespace
+namespaces
 Navi
 NUMA
 NumPy
@@ -145,6 +147,7 @@ OMPT
 OMPX
 ONNX
 OpenCL
+OpenGL
 OpenMP
 OpenVX
 OSS
@@ -234,6 +237,7 @@ uninstallation
 unsqueeze
 unstacking
 unswitching
+untrusted
 untuned
 USM
 Vanhoucke
@@ -246,6 +250,7 @@ vectorizes
 VGPR
 VGPRs
 VMWare
+Vulkan
 wavefront
 wavefronts
 WGP


### PR DESCRIPTION
Markdown supports "out-of-line" links of the format [link-text][link-name], followed by [link-name]: <link-url> on its own line somewhere in the document.
Don't spellcheck link-name or the link definition line.

The word list additions are for the GPU isolation guide.