### PR TITLE
fix(core.py): use older version of pretty format in git log command

### DIFF
--- a/src/rocm_docs/core.py
+++ b/src/rocm_docs/core.py
@@ -273,7 +273,7 @@ def _get_all_pages(output_directory: str):
 
 
 def _get_time_last_modified(path: str) -> str:
-    return subprocess.getoutput(f"git log -1 --pretty='format:%cs' {path}")
+    return subprocess.getoutput(f"git log -1 --pretty=format:%cd --date=short {path}")
 
 
 def _estimate_read_time(file_name: str) -> str:


### PR DESCRIPTION
since Read the Docs uses git version 2.17.1, which does not support the `%cs` format option