### PR TITLE
Use text instead of icons for article OS info

### DIFF
--- a/src/rocm_docs/core.py
+++ b/src/rocm_docs/core.py
@@ -186,14 +186,16 @@ def _set_page_article_info(
         if os.path.isfile(path_source) is False:
             path_source = page["file"] + ".md"
 
-        font_awesome_os = ""
+        article_os_info = ""
         if "os" not in page.keys():
             page["os"] = app.config.all_article_info_os
         if "linux" in page["os"]:
-            font_awesome_os += '<i class="fa-brands fa-linux fa-2xl fa-fw"></i>'
+            article_os_info += 'Linux'
         if "windows" in page["os"]:
-            font_awesome_os += '<i class="fa-brands fa-windows fa-2xl fa-fw"></i>'
-        modified_info = article_info.replace("<!--osicons-->", font_awesome_os)
+            if len(article_os_info) > 0:
+                article_os_info += ' and '
+            article_os_info += 'Windows'
+        modified_info = article_info.replace("<!--os-info-->", article_os_info)
 
         author = app.config.all_article_info_author
         if "author" in page.keys():
@@ -231,11 +233,13 @@ def _set_all_article_info(
         if page in specific_pages:
             continue
 
-        font_awesome_os = ""
+        article_os_info = ""
         if "linux" in app.config.all_article_info_os:
-            font_awesome_os += '<i class="fa-brands fa-linux fa-2xl fa-fw"></i>'
+            article_os_info += 'Linux'
         if "windows" in app.config.all_article_info_os:
-            font_awesome_os += '<i class="fa-brands fa-windows fa-2xl fa-fw"></i>'
+            if len(article_os_info) > 0:
+                article_os_info += ' and '
+            article_os_info += 'Windows'
 
         page_key = Path(page).stem
         if page_key in source_map.keys():
@@ -246,7 +250,7 @@ def _set_all_article_info(
         if len(date_info) == 0:
             date_info = app.config.all_article_info_date
 
-        modified_info = article_info.replace("<!--osicons-->", font_awesome_os)
+        modified_info = article_info.replace("<!--os-info-->", article_os_info)
         modified_info = modified_info.replace("AMD", app.config.all_article_info_author)
         modified_info = modified_info.replace("2023", date_info)
         modified_info = modified_info.replace("5 min read", _estimate_read_time(page))

--- a/src/rocm_docs/rocm_docs_theme/components/article-info.html
+++ b/src/rocm_docs/rocm_docs_theme/components/article-info.html
@@ -1,7 +1,7 @@
 <div id="rocm-docs-core-article-info" class="sd-container-fluid sd-sphinx-override sd-p-0 sd-mt-2 sd-mb-4 sd-p-2 sd-rounded-1 docutils">
 <div class="sd-row sd-row-cols-2 sd-gx-2 sd-gy-1 docutils">
 <div class="sd-col sd-col-auto sd-d-flex-row sd-align-minor-center docutils" style="color:gray;">
-    OS: <!--osicons-->
+    Applies to <!--os-info-->
 </div>
 <div class="sd-col sd-d-flex-row sd-align-minor-center docutils">
 <div class="sd-container-fluid sd-sphinx-override docutils">


### PR DESCRIPTION
change from icons to text due to copyright issues with Windows logo