### PR TITLE
Another round of good 'ol css fixes

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -127,7 +127,8 @@ ul.bd-breadcrumbs li.breadcrumb-item {
 }
 
 .bd-sidebar-primary {
-  margin-top: 3.5rem;
+  top: 3.5rem;
+  height: calc(100vh - 3.5rem);
 }
 
 .sbt-scroll-pixel-helper {
@@ -136,13 +137,15 @@ ul.bd-breadcrumbs li.breadcrumb-item {
 
 @media (min-width: 576px) and (max-width: 959.98px) {
   .bd-sidebar-primary {
-    margin-top: 5.5rem;
+    top: 5.5rem;
+    height: calc(100vh - 5.5rem);
   }
 }
 
 @media(min-width: 960px) {
   .bd-sidebar-primary {
-    margin-top: unset;
+    top: 0;
+    height: 100vh;
   }
 }
 

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -896,7 +896,14 @@ header.common-header
 }
 
 @media (max-width: 959.98px) {
+  input#__primary:not(:checked) ~ header.common-header {
+    /* top will be ignored when statically positioned, so this only applies
+       when the sidebar is opened and its used to animate it to its place. */
+    top: -5.5em;
+  }
   input#__primary:checked ~ header.common-header {
-    position: fixed;
+    position: sticky;
+    top: 0;
+    transition: top ease 0.25s;
   }
 }

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -216,7 +216,6 @@ header.common-header .navbar > .main-nav .navbar-nav-container {
   height: auto;
   order: 3;
   overflow-x: hidden;
-  overflow-y: scroll;
   position: fixed;
   right: 0;
   top: 3.5rem;


### PR DESCRIPTION
- Fix menu having a scrollbar when it is not needed
- Fix the page "jumping" when the sidebar is opened on small screens
- Animate the header appearing with the sidebar on small screens
- Fix the read the docs version selector not appearing on the sidebar on small screens