### PR TITLE
Refactor utility code

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -53,10 +53,6 @@ def _copy_files(app: Sphinx):
                 # unzipping and/or the creation of a temporary file.
                 # This is not the case when opening the file as a
                 # stream.
-                if entry is None:
-                    print("none")
-                else:
-                    print("some")
                 with entry.open("rb") as infile:  # type: ignore
                     with open(entry_path, "wb") as out:
                         shutil.copyfileobj(infile, out)


### PR DESCRIPTION
Removes an extra print statement and use urllib to simplify regex

RE: https://github.com/ROCmSoftwarePlatform/hipSOLVER/pull/161#pullrequestreview-1434766240

Update: Reverted change to use urlparse in latest

> `urlparse` probably won't work, as we also need to accommodate SSH remotes (e.g. `git@github.com:RadeonOpenCompute/rocm-docs-core.git`)

