### PR TITLE
ci(spellcheck): adds "disambiguates" to vocabulary

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -60,6 +60,7 @@ datatypes
 de
 denormalize
 deserializers
+disambiguates
 distro
 DL
 DNN


### PR DESCRIPTION
Fixes CI on https://github.com/RadeonOpenCompute/ROCm/pull/2167