### PR TITLE
build(pyproject.toml): set min doxysphinx version to 3.3.2 when using api_reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ documentation="https://docs.amd.com"
 
 [project.optional-dependencies]
 api_reference = [
-  "doxysphinx>=3.2.1,!=3.3.0,!=3.3.1"
+  "doxysphinx>=3.3.2"
 ]
 development = [
   "commitizen>=2.42"


### PR DESCRIPTION
to resolve issue with dependabot

```
updater |   ERROR: Could not find a version that satisfies the requirement doxysphinx==3.2.1 (from rocm-docs-core[api_reference]==0.13.1) (from versions: 3.3.0, 3.3.1, 3.3.2, 3.3.3)

...

updater | pip._internal.exceptions.DistributionNotFound: No matching distribution found for doxysphinx==3.2.1 (from rocm-docs-core[api_reference]==0.13.1)
```
