### PR TITLE
fix(__init__.py): stop searching CMakeLists.txt for version string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ for sphinx_var in ROCmDocs.SPHINX_VARS:
 
 ### Documentation
 
-Build documentation by running the commands below:
+The `rocm-docs-core` documentation is viewable at [https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/](https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/)
+
+To build the `rocm-docs-core` documentation locally, run the commands below:
 
 ```
 pip install -r requirements.txt

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -3,7 +3,6 @@
 from typing import Dict, List, Optional, Union
 
 import os
-import re
 
 from rocm_docs.core import setup
 
@@ -35,7 +34,6 @@ class ROCmDocs:
     ) -> None:
         """Intialize ROCmDocs."""
         self._project_name: str = project_name
-        self._version_string = version_string
         self.extensions: List[str] = []
         self.html_title: str
         self.html_theme: str
@@ -81,18 +79,6 @@ class ROCmDocs:
         """Set up default RTD variables."""
         self.extensions.append("rocm_docs")
         full_project_name = self._project_name
-        if self._version_string is None and os.path.exists("../CMakeLists.txt"):
-            with open("../CMakeLists.txt", encoding="utf8") as file:
-                for line in file.readlines():
-                    if "VERSION_STRING" in line:
-                        self._version_string = re.sub(
-                            r"^.*VERSION_STRING.*\s\"([0-9]+(?:\.[0-9]+)*).*$",
-                            "\1",
-                            line,
-                        )
-                        break
-        if self._version_string is not None and len(self._version_string) > 0:
-            full_project_name += f" {self._version_string}"
         self.html_title = full_project_name
         self.html_theme = "rocm_docs_theme"
 

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -1,4 +1,7 @@
-"""Set up variables for documentation of ROCm projects using RTD."""
+"""
+Set up variables for documentation of ROCm projects
+that are using Read the Docs.
+"""
 
 from typing import Dict, List, Optional, Union
 

--- a/src/rocm_docs/__init__.py
+++ b/src/rocm_docs/__init__.py
@@ -1,4 +1,5 @@
-"""
+"""Defines the ROCmDocs package.
+
 Set up variables for documentation of ROCm projects
 that are using Read the Docs.
 """


### PR DESCRIPTION
since each project has the version string in a different location, this must be done on a case-by-case basis