### PR TITLE
feat(projects): expose project urls to html templates

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -33,7 +33,7 @@ projects:
   roctracer: https://rocm.docs.amd.com/projects/roctracer/en/${version}
   rocm-docs-core: https://rocm.docs.amd.com/projects/rocm-docs-core/en/${version}
   rocm-validation-suite: https://rocm.docs.amd.com/projects/ROCmValidationSuite/en/${version}
-  rocm: https://rocm.docs.amd.com/en/develop/
+  rocm: https://rocm.docs.amd.com/en/${version}
   rocprim: https://rocm.docs.amd.com/projects/rocPRIM/en/${version}
   rocrand: https://rocm.docs.amd.com/projects/rocRAND/en/${version}
   rocsolver: https://rocm.docs.amd.com/projects/rocSOLVER/en/${version}

--- a/src/rocm_docs/rocm_docs_theme/components/left-side-menu.html
+++ b/src/rocm_docs/rocm_docs_theme/components/left-side-menu.html
@@ -1,10 +1,3 @@
-{% macro navbar_item(branch) -%}
-    {% if branch in ["develop", "amd-master", "amd-staging", "master"] %}
-    <a class="navbar-brand logo" href="https://rocm.docs.amd.com/en/develop">
-    {% else %}
-    <a class="navbar-brand logo" href="https://rocm.docs.amd.com/en/latest">
-    {% endif %}
-        <p>ROCm Documentation Home</p>
-    </a>
-{%- endmacro -%}
-{{ navbar_item(theme_repository_branch) }}
+<a class="navbar-brand logo" href="{{ projects['rocm'] }}">
+    <p>ROCm Documentation Home</p>
+</a>

--- a/src/rocm_docs/rocm_docs_theme/sections/footer.html
+++ b/src/rocm_docs/rocm_docs_theme/sections/footer.html
@@ -5,7 +5,7 @@
                 <div class="col-12 text-center">
                     <ul>
                         <li><a href="https://www.amd.com/en/corporate/copyright" target="_blank">Terms and Conditions</a></li>
-                        <li><a href="https://rocm.docs.amd.com/en/latest/release/licensing.html">ROCm Licenses and Disclaimers</a></li>
+                        <li><a href="{{ projects['rocm'] }}/release/licensing.html">ROCm Licenses and Disclaimers</a></li>
                         <li><a href="https://www.amd.com/en/corporate/privacy" target="_blank">Privacy</a></li>
                         <li><a href="https://www.amd.com/en/corporate/trademarks" target="_blank">Trademarks</a></li>
                         <li><a href="https://www.amd.com/system/files/documents/statement-human-trafficking-forced-labor.pdf" target="_blank">Statement on Forced Labor</a></li>

--- a/src/rocm_docs/rocm_docs_theme/sections/header.html
+++ b/src/rocm_docs/rocm_docs_theme/sections/header.html
@@ -13,11 +13,11 @@
                 <div class="vr vr mx-40 my-25"></div>
                 {% macro top_level_header(branch) -%}
                     {% if branch in ["develop", "master", "main", "amd-master", "amd-staging"] %}
-                    <a class="klavika-font hover-opacity" href="https://rocm.docs.amd.com/en/latest/">ROCm&#8482; Platform <i>Future Release</i></a>
+                    <a class="klavika-font hover-opacity" href="{{ projects['rocm'] }}">ROCm&#8482; Platform <i>Future Release</i></a>
                     {% elif "5.6." in branch %}
-                    <a class="klavika-font hover-opacity" href="https://rocm.docs.amd.com/en/latest/">ROCm&#8482; Platform <i>Release Candidate 5.6</i></a>
+                    <a class="klavika-font hover-opacity" href="{{ projects['rocm'] }}">ROCm&#8482; Platform <i>Release Candidate 5.6</i></a>
                     {% else %}
-                    <a class="klavika-font hover-opacity" href="https://rocm.docs.amd.com/en/latest/">ROCm&#8482; Platform <i>{{ branch }}</i></a>
+                    <a class="klavika-font hover-opacity" href="{{ projects['rocm'] }}">ROCm&#8482; Platform <i>{{ branch }}</i></a>
                     {% endif %}
                 {%- endmacro -%}
                 {{ top_level_header(theme_repository_branch | replace("docs/", "")) }}


### PR DESCRIPTION
Project urls (from `projects.yaml`) are exposed as `projects[project_name]` to jinja now, this includes the branch mapping logic.

Use this to set the main doc link, this makes versioned releases link to the correct version of the main doc page (rocm).