### PR TITLE
fix: hardcode the url for ROCm docs

### DIFF
--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import json
 import os
-import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -307,7 +306,6 @@ def _update_banner_config(
 
     latest_version = "5.5.1"
     latest_version_string = f"docs-{latest_version}"
-    latest_url = re.sub(r"([^\/]+$)", latest_version_string, url)
     announcement_info = ""
 
     if branch == latest_version_string:
@@ -315,12 +313,12 @@ def _update_banner_config(
     elif branch.startswith("docs-"):
         # turn off Python black for this line to prevent conflict with other Python linters
         # fmt: off
-        announcement_info = f"This is an old version of ROCm documentation. Read the <a href='{latest_url}'>latest ROCm release documentation</a> to stay informed of all our developments."
+        announcement_info = "This is an old version of ROCm documentation. Read the <a href='https://rocm.docs.amd.com/en/latest/'>latest ROCm release documentation</a> to stay informed of all our developments."
         # fmt: on
 
     elif branch == development_branch:
         # fmt: off
-        announcement_info = f"This page contains proposed changes for a future release of ROCm. Read the <a href='{latest_url}'>latest Linux release of ROCm documentation</a> for your production environments."
+        announcement_info = "This page contains proposed changes for a future release of ROCm. Read the <a href='https://rocm.docs.amd.com/en/latest/'>latest Linux release of ROCm documentation</a> for your production environments."
         # fmt: on
 
     app.add_config_value(


### PR DESCRIPTION
point directly to https://rocm.docs.amd.com/en/latest/