### PR TITLE
Include metadata in head tag for all pages

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/layout.html
+++ b/src/rocm_docs/rocm_docs_theme/layout.html
@@ -1,5 +1,9 @@
 {% extends "sphinx_book_theme/layout.html" %}
 
+{% block extrahead %}
+    <meta name="google-site-verification" content="ZOn0RZC0Pwzlmf2SaE0bRttWk1YzOhuslbpxUDchQ90" />
+{% endblock %}
+
 {% block docs_navbar %}
     {%- include "sections/header.html" %}
 {% endblock %}


### PR DESCRIPTION
Adds the google-site-verification metadata near the end of the `<head>` section for all pages via the `layout.html`

![image](https://github.com/RadeonOpenCompute/rocm-docs-core/assets/22262939/aa8e4183-13bf-4ab4-9c6b-ec76a0a4f054)
