### PR TITLE
feat: Add "local" flavor for providing the flavor in the project

### DIFF
--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -54,7 +54,7 @@ def _update_theme_options(app: Sphinx) -> None:
     theme_opts = get_theme_options_dict(app)
     _update_repo_opts(app.srcdir, url, branch, theme_opts)
 
-    supported_flavors = ["rocm"]
+    supported_flavors = ["rocm", "local"]
     flavor = theme_opts.get("flavor", "rocm")
     if flavor not in supported_flavors:
         logger.error(


### PR DESCRIPTION
This flavor doesn't ship with any files, they are to be provided by users.
To use this flavor make a customized copy of a flavor in the project directory and set the following options in `conf.py`

```python
html_theme_options["flavor"] = "local"
templates_path = ["."] # Use the current folder for templates
```