### PR TITLE
feat: Add config option to specify doxygen exe

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -94,19 +94,16 @@ def _run_doxygen(app: Sphinx, config: Config) -> None:
         ) from err
 
     if config["doxygen_executable"] is None:
-        doxygen_exe = shutil.which("doxygen")
+        cmd_path = shutil.which("doxygen")
+        if cmd_path is None:
+           raise RuntimeError(
+                "'doxygen' command not found! Make sure that "
+                "doxygen is installed and in the PATH or specify "
+                "via doxygen_executable configuration variable."
+            )
+        doxygen_exe = Path(cmd_path)
     else:
-        doxygen_path: Path = Path(config["doxygen_executable"]).absolute()
-        if doxygen_path.is_file():
-            doxygen_exe = str(doxygen_path)
-        else:
-            doxygen_exe = None
-    if doxygen_exe is None:
-        raise RuntimeError(
-            "'doxygen' command not found! Make sure that "
-            "doxygen is installed and in the PATH or specify "
-            "via doxygen_executable configuration variable."
-        )
+        doxygen_exe = Path(app.confdir, config.doxygen_executable)
 
     doxyfile = Path(app.confdir, config["doxyfile"]).absolute()
     if not doxyfile.is_file():

--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -96,7 +96,7 @@ def _run_doxygen(app: Sphinx, config: Config) -> None:
     if config["doxygen_executable"] is None:
         cmd_path = shutil.which("doxygen")
         if cmd_path is None:
-           raise RuntimeError(
+            raise RuntimeError(
                 "'doxygen' command not found! Make sure that "
                 "doxygen is installed and in the PATH or specify "
                 "via doxygen_executable configuration variable."

--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -93,17 +93,25 @@ def _run_doxygen(app: Sphinx, config: Config) -> None:
             " and be readable."
         ) from err
 
+    if config["doxygen_executable"] is None:
+        doxygen_exe = shutil.which("doxygen")
+    else:
+        doxygen_path: Path = Path(config["doxygen_executable"]).absolute()
+        if doxygen_path.is_file():
+            doxygen_exe = str(doxygen_path)
+        else:
+            doxygen_exe = None
+    if doxygen_exe is None:
+        raise RuntimeError(
+            "'doxygen' command not found! Make sure that "
+            "doxygen is installed and in the PATH or specify "
+            "via doxygen_executable configuration variable."
+        )
+
     doxyfile = Path(app.confdir, config["doxyfile"]).absolute()
     if not doxyfile.is_file():
         raise ConfigError(
             f"Expected doxyfile {doxyfile} to exist and be readable."
-        )
-
-    doxygen_exe = shutil.which("doxygen")
-    if doxygen_exe is None:
-        raise RuntimeError(
-            "'doxygen' command not found! Make sure that "
-            "doxygen is installed and in the PATH"
         )
 
     # Running doxygen requires that the files are already copied because
@@ -198,6 +206,12 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.add_config_value(
         "doxygen_root", ".doxygen", rebuild="", types=[None, str, os.PathLike]
+    )
+    app.add_config_value(
+        "doxygen_executable",
+        None,
+        rebuild="",
+        types=[None, str, "os.PathLike[Any]"],
     )
     app.add_config_value(
         "doxyfile",


### PR DESCRIPTION
As part of the effort to build the documentation of (potentially multiple) projects from CMake, I've added the ability for Sphinx to call a Doxygen install that isn't on the PATH (as on Windows, that is rarely the case). Specifying `-D doxygen_executable=<path_to_doxygen.exe>` then sphinx will use that instead of asking `shutil` where it's found on the PATH.