### PR TITLE
feat: Add reusable md rst linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,11 +12,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint-rest:
+    name: "RestructuredText"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install rst-lint
+        run: pip install restructuredtext-lint
+      - name: Lint ResT files
+        run: rst-lint ${{ join(github.workspace, '/docs') }}
+
+  lint-md:
+    name: "Markdown"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Use markdownlint-cli2
+        uses: DavidAnson/markdownlint-cli2-action@v10.0.1
+        with:
+          globs: "**/*.md"
+
   spelling:
     name: "Spelling"
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-    - name: Run spellcheck
-      uses: rojopolis/spellcheck-github-actions@0.30.0
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Fetch config
+        if: ${{ ! contains( github.repository, 'rocm-docs-core') }}
+        shell: sh
+        run: |
+          curl --silent --show-error --fail --location https://raw.github.com/RadeonOpenCompute/rocm-docs-core/develop/.spellcheck.yaml -O
+          curl --silent --show-error --fail --location https://raw.github.com/RadeonOpenCompute/rocm-docs-core/develop/.wordlist.txt >> .wordlist.txt
+      - name: Run spellcheck
+        uses: rojopolis/spellcheck-github-actions@0.30.0
+      - name: On fail
+        if: failure()
+        run: |
+          echo "Please check for spelling mistakes or add them to '.wordlist.txt' in either the root of this project or in rocm-docs-core."


### PR DESCRIPTION
This PR pushes (hopefully) all the changes required to have reusable Markdown and ReST linting.

The original work done by @Maetveis can be found [here](https://github.com/StreamHPC/rocm-docs-core/blob/md-rst-linting/.github/workflows/linting.yml) and the [previous](https://github.com/RadeonOpenCompute/rocm-docs-core/pull/310) too hasty implementation missed the MD and RST checks, but most importantly an important part of the spelling check, the part that checks whether the repo running the workflow is rocm-docs-core or not and if not, fetches the spelling check config file.

Still related to: https://github.com/RadeonOpenCompute/ROCm/pull/2207