### PR TITLE
fix(projects.yaml): Add ROCmCMakeBuildTools to projects.yaml

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -63,3 +63,4 @@ projects:
   rtd: https://docs.readthedocs.io/en/stable/
   sphinx: https://www.sphinx-doc.org/en/master/
   transferbench: https://rocm.docs.amd.com/projects/TransferBench/en/${version}
+  rocmcmakebuildtools: https://rocm.docs.amd.com/projects/ROCmCMakeBuildTools/en/${version}


### PR DESCRIPTION
https://github.com/RadeonOpenCompute/rocm-cmake/pull/142