### PR TITLE
Trigger status checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.22.0 (2023-08-31)
+
+### Feat
+
+- **projects.yaml**: add hiptensor to projects.yaml
+
+### Fix
+
+- **projects.yaml**: Add ROCmCMakeBuildTools to projects.yaml
+
 ## v0.21.0 (2023-08-29)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = 'rocm-docs-core'
-version = "0.21.0"
+version = "0.22.0"
 authors=[
   {name="Lauren Wrubleski", email="Lauren.Wrubleski@amd.com"}
 ]
@@ -71,7 +71,7 @@ color = true
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.21.0"
+version = "0.22.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 annotated_tag = true


### PR DESCRIPTION
Because of branch protection rules status checks are required before merging, but they are not triggered by pushes from github actions (pushes authenticated via `GITHUB_TOKEN`).

Quoting from [Github actions / Using the `GITHUB_TOKEN` in a workflow](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.
> ...
> For example, if a workflow run pushes code using the repository's GITHUB_TOKEN, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

This PR is only here to trigger the workflow, so the fast-forward of develop can succeed.