### PR TITLE
"Skip" status checks for version bump commit

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: Docs Linting
 
 on:
   workflow_call:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,10 @@
+name: Code Linting
 on:
   pull_request:
 
 jobs:
   lint:
-    name: Python linting
+    name: Python
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -86,9 +86,34 @@ jobs:
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
+  mark-status-checks:
+    name: Mark required status checks as succeeded
+    needs: [bump-version]
+    runs-on: ubuntu-latest
+    if: needs.bump-version.outputs.bumped == 'true'
+    steps:
+    - shell: sh
+      run: |
+        REPO="${{ github.repository }}"
+        SHA="${{ needs.bump-version.outputs.sha }}"
+
+        printf '%s' "${{ vars.REQUIRED_CHECK_CONTEXTS }}" | \
+        while IFS="" read -r CONTEXT; do
+          # Mark each check as succeeded
+          gh api "/repos/$REPO/statuses/$SHA"                     \
+            --method POST                                         \
+            --header "Accept: application/vnd.github+json"        \
+            --header "X-GitHub-Api-Version: 2022-11-28"           \
+            --field state=success                                 \
+            --field description='Skipped for version bump commit' \
+            --raw-field context="$CONTEXT"
+        done
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   call-sync-branches:
     name: Trigger merge
-    needs: [bump-version]
+    needs: [bump-version, mark-status-checks]
     if: needs.bump-version.outputs.bumped == 'true'
     uses: ./.github/workflows/sync_branches.yml
     with:


### PR DESCRIPTION
Because of branch protection rules status checks are required before merging, but they are not triggered by pushes from github actions (pushes authenticated via `GITHUB_TOKEN`).

Quoting from [Github actions / Using the `GITHUB_TOKEN` in a workflow](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.
> ...
> For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.

To remedy this and allow the merge back to develop succeed, "skip" the checks for the bump commit, by marking the required statuse checks as successful from the github API. The list of such checks is available from the API, but requires admin access and cannot be queried using the `GITHUB_TOKEN`.

Therefore to make this work **an action variable must be defined with the name `REQUIRED_CHECK_CONTEXTS`**. It's value should be the names of the required checks, one for each line followed by a final newline.

E.g.

```plaintext
Spelling
RestructuredText
Markdown

```

The GitHub docs section [Creating configuration variables for a repository](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) explains how to add variables to the repo.
