### PR TITLE
Update header version to 5.7

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,4 @@
 /_build
 /_doxygen
+404.md
+data/AMD-404.png

--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -295,9 +295,9 @@ def _update_theme_configs(
     app: Sphinx, current_project: Optional[_Project], current_branch: str
 ) -> None:
     """Update configurations for use in theme.py"""
-    latest_version = "5.6.1"
+    latest_version = "5.7"
     latest_version_string = f"docs-{latest_version}"
-    release_candidate = "5.7"
+    release_candidate = "5.8"
     release_candidate_string = f"docs-{release_candidate}"
 
     development_branch = _Project.default_value("development_branch")

--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -297,7 +297,7 @@ def _update_theme_configs(
     """Update configurations for use in theme.py"""
     latest_version = "5.7"
     latest_version_string = f"docs-{latest_version}"
-    release_candidate = "5.8"
+    release_candidate = "6.0"
     release_candidate_string = f"docs-{release_candidate}"
 
     development_branch = _Project.default_value("development_branch")

--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -295,9 +295,9 @@ def _update_theme_configs(
     app: Sphinx, current_project: Optional[_Project], current_branch: str
 ) -> None:
     """Update configurations for use in theme.py"""
-    latest_version = "5.7"
+    latest_version = "5.7.0"
     latest_version_string = f"docs-{latest_version}"
-    release_candidate = "6.0"
+    release_candidate = "6.0.0"
     release_candidate_string = f"docs-{release_candidate}"
 
     development_branch = _Project.default_value("development_branch")

--- a/src/rocm_docs/rocm_docs_theme/theme.conf
+++ b/src/rocm_docs/rocm_docs_theme/theme.conf
@@ -10,5 +10,5 @@ flavor = rocm
 
 link_main_doc = True
 
-header_latest_version = 5.7
-header_release_candidate = 6.0
+header_latest_version = 5.7.0
+header_release_candidate = 6.0.0

--- a/src/rocm_docs/rocm_docs_theme/theme.conf
+++ b/src/rocm_docs/rocm_docs_theme/theme.conf
@@ -10,5 +10,5 @@ flavor = rocm
 
 link_main_doc = True
 
-header_latest_version = 5.6.1
-header_release_candidate = 5.7
+header_latest_version = 5.7
+header_release_candidate = 5.8

--- a/src/rocm_docs/rocm_docs_theme/theme.conf
+++ b/src/rocm_docs/rocm_docs_theme/theme.conf
@@ -11,4 +11,4 @@ flavor = rocm
 link_main_doc = True
 
 header_latest_version = 5.7
-header_release_candidate = 5.8
+header_release_candidate = 6.0


### PR DESCRIPTION
- [rocm-docs-core](https://github.com/RadeonOpenCompute/rocm-docs-core) version is bumped by this commit

- the update will be pushed to all projects

- then cherry picked into `release/rocm-rel-5.7` branch