### PR TITLE
ci(linting.yml): add markdown link checks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        folder-path: 'docs'
 
   spelling:
     name: "Spelling"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,6 +42,7 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         folder-path: 'docs'
+        file-path: './README.md'
 
   spelling:
     name: "Spelling"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,6 +34,13 @@ jobs:
         with:
           globs: "**/*.md"
 
+  md-link-check:
+    name: "Markdown Link Check"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+
   spelling:
     name: "Spelling"
     runs-on: ubuntu-latest

--- a/docs/user_guide/doxygen_integration.md
+++ b/docs/user_guide/doxygen_integration.md
@@ -5,6 +5,7 @@ call the `run_doxygen` method in the configuration file (`conf.py`)
 located in the `docs` folder.
 Then add the Doxygen output to the table of contents (`_toc.yml.in`)
 
+<!-- markdown-link-check-disable-next-line -->
 This project has [Demo Doxygen Docs here](../demo/doxygen/html/index),
 which was achieved using the [configuration here](https://github.com/RadeonOpenCompute/rocm-docs-core/blob/develop/docs/conf.py)
 and the [table of contents set here](https://github.com/RadeonOpenCompute/rocm-docs-core/blob/develop/docs/.sphinx/_toc.yml.in).

--- a/docs/user_guide/linking.md
+++ b/docs/user_guide/linking.md
@@ -51,4 +51,5 @@ The following Markdown:
 
 will be rendered as the following link:
 
+<!-- markdown-link-check-disable-next-line -->
 [Link Text](../index)


### PR DESCRIPTION
uses https://github.com/gaurav-nelson/github-action-markdown-link-check (Github action for https://github.com/tcort/markdown-link-check)

closes https://github.com/RadeonOpenCompute/rocm-docs-core/issues/393