### PR TITLE
Copy files relative to source directory

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -30,10 +30,7 @@ else:
 def _copy_files(app: Sphinx) -> None:
     """Insert additional files into workspace."""
     pkg = importlib_resources.files("rocm_docs")
-    try:
-        Path(app.confdir, "_doxygen").mkdir()
-    except FileExistsError:
-        pass
+    Path(app.srcdir, "_doxygen").mkdir(exist_ok=True)
     util.copy_from_package(
         app, pkg / "data/_doxygen", "data/_doxygen", "_doxygen"
     )

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -133,13 +133,21 @@ def get_branch(
 def copy_from_package(
     app: Sphinx, data_dir: Traversable, read_path: str, write_path: str
 ) -> None:
-    """Copy files from package specified in data_dir."""
+    """Copy files from package specified in data_dir.
+
+    Args:
+      app: The `Sphinx` instance
+      data_dir: source path to package files
+      read_path: relative path corresponding to `data_dir`
+      write_path: path to store output files, relative paths are interpreted
+        relative to the sphinx source directory.
+    """
     if not data_dir.is_dir():
         raise NotADirectoryError(
             f"Expected path {read_path}/{data_dir} to be traversable."
         )
     for entry in data_dir.iterdir():
-        entry_path: Path = Path(app.confdir) / write_path / entry.name
+        entry_path: Path = Path(app.srcdir) / write_path / entry.name
         if entry.is_dir():
             entry_path.mkdir(parents=True, exist_ok=True)
             copy_from_package(


### PR DESCRIPTION
For relative files this is what we want most of the time, as we're copying
sources to be picked up by sphinx. Usually the configuration and source
directory are the same, so this error went unnoticed.

Also fix/simplify creating the folder for `_doxygen`