### PR TITLE
fix(doxygen.py): Pass doxygen executable to doxysphinx

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -90,7 +90,7 @@ def _run_doxygen(app: Sphinx, config: Config) -> None:
         raise RuntimeError("Failed when running doxygen") from err
 
     _update_breathe_settings(app, doxygen_root)
-    _run_doxysphinx(app, doxygen_root, doxyfile)
+    _run_doxysphinx(app, doxygen_root, doxyfile, doxygen_exe)
 
 
 def _update_breathe_settings(app: Sphinx, doxygen_root: Path) -> None:
@@ -131,7 +131,9 @@ def _update_breathe_settings(app: Sphinx, doxygen_root: Path) -> None:
     setattr(app.config, "breathe_default_project", project_name)
 
 
-def _run_doxysphinx(app: Sphinx, doxygen_root: Path, doxyfile: Path) -> None:
+def _run_doxysphinx(
+    app: Sphinx, doxygen_root: Path, doxyfile: Path, doxygen_exe: Path
+) -> None:
     if not app.config.doxysphinx_enabled:
         return
 
@@ -152,6 +154,7 @@ def _run_doxysphinx(app: Sphinx, doxygen_root: Path, doxyfile: Path) -> None:
                 "-m",
                 "doxysphinx",
                 "build",
+                "--doxygen_exe=" + str(doxygen_exe.absolute()),
                 app.srcdir,
                 app.outdir,
                 doxyfile,


### PR DESCRIPTION
PR #306 introduced a config option to set doxygen executable, but we failed to propagate it to doxysphinx too. Before this change doxysphinx always looks for the command `doxygen` in the PATH.