### PR TITLE
build: Add py.typed marker to "export" type definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ rocm_docs_theme = "rocm_docs.theme"
 where=["src"]
 
 [tool.setuptools.package-data]
-rocm_docs = ["data/**/*", "rocm_docs_theme/**/*"]
+rocm_docs = ["data/**/*", "rocm_docs_theme/**/*", "py.typed"]
 
 [tool.black]
 target-version = ["py38"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -233,6 +233,7 @@ tqdm==4.66.1
 typing-extensions==4.8.0
     # via
     #   black
+    #   filelock
     #   mypy
     #   pydata-sphinx-theme
 urllib3==2.0.6

--- a/src/rocm_docs/py.typed
+++ b/src/rocm_docs/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. This package uses inline types.


### PR DESCRIPTION
Without this file type out definitions are not visible to projects using rocm_docs_core. This is not really a problem since our users are sphinx cofiguration files `conf.py` where type-checking doesn't provide much benefit, but its still nice to export our type annotations given that we have them.