### PR TITLE
fix(theme.py): Partially handle not being in a git repository

### DIFF
--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -16,15 +16,22 @@ from rocm_docs import util
 logger = sphinx.util.logging.getLogger(__name__)
 
 
-def _update_repo_opts(
-    srcdir: str, url: str, branch: str, theme_opts: Dict[str, Any]
-) -> None:
-    default_branch_options = {
+def _update_repo_opts(srcdir: str, theme_opts: Dict[str, Any]) -> None:
+    default_branch_options: Dict[str, Any] = {
         "use_edit_page_button": False,
-        "repository_url": url,
-        "repository_branch": branch,
-        "path_to_docs": util.get_path_to_docs(srcdir),
     }
+    try:
+        url, branch = util.get_branch(srcdir)
+        default_branch_options.update(
+            {
+                "repository_url": url,
+                "repository_branch": branch,
+                "path_to_docs": util.get_path_to_docs(srcdir),
+            }
+        )
+    except util.InvalidGitRepositoryError:
+        logger.warning("Not in a Git Directory, disabling repository buttons")
+
     for key, val in default_branch_options.items():
         theme_opts.setdefault(key, val)
 
@@ -50,9 +57,8 @@ def _update_banner(
 
 
 def _update_theme_options(app: Sphinx) -> None:
-    url, branch = util.get_branch(app.srcdir)
     theme_opts = get_theme_options_dict(app)
-    _update_repo_opts(app.srcdir, url, branch, theme_opts)
+    _update_repo_opts(app.srcdir, theme_opts)
 
     supported_flavors = ["rocm", "local"]
     flavor = theme_opts.get("flavor", "rocm")

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 import github
+from git.exc import InvalidGitRepositoryError
 from git.repo import Repo
 from github.GithubException import UnknownObjectException
 from sphinx.application import Sphinx
@@ -165,3 +166,12 @@ def copy_from_package(
             with entry.open("rb") as infile:
                 with open(entry_path, "wb") as out:
                     shutil.copyfileobj(infile, out)
+
+
+__all__ = [
+    "InvalidGitRepositoryError",
+    "VersionType",
+    "get_path_to_docs",
+    "get_branch",
+    "copy_from_package",
+]


### PR DESCRIPTION
Handle in the theme when we're not inside a git repo, by not providing urls in that case.
For testing setting up a git repo for the execution of tests would be very painful, so lets avoid it.