### PR TITLE
Explicit projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,6 +11,7 @@ setting_all_article_info = True
 # Disable fetching projects.yaml, it would be the same as the local one anyway
 # except if a PR modifies it. We want to test with its version in that case
 external_projects_remote_repository = ""
+external_projects = ["hipify", "python", "rocm-docs-core"]
 
 external_projects_current_project = "rocm-docs-core"
 

--- a/docs/developer_guide/projects_yaml.md
+++ b/docs/developer_guide/projects_yaml.md
@@ -40,3 +40,18 @@ Vice-versa if A has set its `development_branch` to `develop` and B sets it to `
 Symbolic versions "latest" and "stable" map to themselves in other projects.
 
 Any other branch maps to "latest".
+
+## Explicitly list external projects
+
+By default the inventories of all external projects defined in `projets.yaml`
+will be downloaded. This can take a long time as it requires a network request
+for each external project.
+
+The `external_projects` configuration option can be set to a list with the names
+of remote projects to fetch inventories from & enable links to.
+The list must be a subset of the project names defined in `projects.yaml`.
+The default value of `"all"` means to fetch all projects.
+
+References to projects that are not in `external_projects` will not be resolved.
+This applies to the terms of contents too, where unresolved references will
+likely cause an error.

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable, Literal
 
+import unittest.mock
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,7 @@ from sphinx.testing.util import SphinxTestApp
 
 import rocm_docs.projects
 
+from .log_fixtures import ExpectLogFixture
 from .sphinx_fixtures import SITES_BASEFOLDER, TEMPLATE_FOLDER
 
 
@@ -53,3 +55,108 @@ def test_pass(
 ) -> None:
     app = build_factory()
     app.build()
+
+
+def str_or_list_to_id(val: str | list[str]) -> str:
+    if isinstance(val, str):
+        return val
+    return ",".join(val)
+
+
+def create_external_project_app(
+    srcdir: Path, external_projects: Any
+) -> unittest.mock.NonCallableMock:
+    app = unittest.mock.NonCallableMock()
+    app.srcdir = srcdir
+    app.config = unittest.mock.NonCallableMock()
+    app.config.overrides = []
+    app.config._raw_config = {
+        "external_projects_current_project": "a",
+        "external_projects": external_projects,
+        "external_toc_template_path": TEMPLATE_FOLDER
+        / ".sphinx"
+        / "_toc.yml.in",
+        "external_toc_path": "_toc.yml",
+        "intersphinx_mapping": {},
+    }
+    app.config.configure_mock(**app.config._raw_config)
+    return app
+
+
+@pytest.mark.parametrize(
+    "external_projects",
+    [[], ["a"], ["b"], ["a", "b"], "all"],
+    ids=str_or_list_to_id,
+)
+@pytest.mark.usefixtures("_no_unexpected_warnings")
+def test_external_projects(
+    external_projects: list[str] | Literal["all"],
+    mocked_projects: dict[str, rocm_docs.projects._Project],
+    tmp_path: Path,
+    with_no_git_repo: ExpectLogFixture.Validator,
+) -> None:
+    with_no_git_repo.required = False
+    app = create_external_project_app(tmp_path, external_projects)
+    rocm_docs.projects._update_config(app, app.config)
+
+    keys = (
+        external_projects
+        if external_projects != "all"
+        else mocked_projects.keys()
+    )
+
+    expected_mapping = {
+        k: (v.target, tuple(v.inventory))
+        for k, v in mocked_projects.items()
+        if k in keys
+    }
+    assert app.config.intersphinx_mapping == expected_mapping
+
+    expected_context = {
+        k: v.target for k, v in mocked_projects.items() if k in keys
+    }
+    assert app.config.projects_context["projects"] == expected_context
+
+
+@pytest.mark.usefixtures("mocked_projects", "_no_unexpected_warnings")
+def test_external_projects_invalid_value(
+    expect_log: ExpectLogFixture,
+    with_no_git_repo: ExpectLogFixture.Validator,
+    tmp_path: Path,
+) -> None:
+    with_no_git_repo.required = False
+    app = create_external_project_app(tmp_path, "invalid_value")
+
+    with expect_log(
+        "sphinx.rocm_docs.projects",
+        "ERROR",
+        'Unexpected value "invalid_value" in external_projects.\n'
+        'Must be set to a list of project names or "all" to enable all projects'
+        " defined in projects.yaml",
+    ):
+        rocm_docs.projects._update_config(app, app.config)
+
+
+@pytest.mark.usefixtures("_no_unexpected_warnings")
+def test_external_projects_unkown_project(
+    expect_log: ExpectLogFixture,
+    mocked_projects: dict[str, rocm_docs.projects._Project],
+    with_no_git_repo: ExpectLogFixture.Validator,
+    tmp_path: Path,
+) -> None:
+    with_no_git_repo.required = False
+    # First keys of mocked_projects
+    a_defined_project = next(iter(mocked_projects.keys()))
+    app = create_external_project_app(
+        tmp_path, [a_defined_project, "unknown_project", "foo"]
+    )
+
+    with expect_log(
+        "sphinx.rocm_docs.projects",
+        "ERROR",
+        'Unknown projects: ["unknown_project", "foo"] in external_projects.\n'
+        "Valid projects are: [{}]".format(
+            ", ".join([f'"{p}"' for p in mocked_projects])
+        ),
+    ):
+        rocm_docs.projects._update_config(app, app.config)


### PR DESCRIPTION
Allow to fetch project sphinx indices explicitly

Description copied from the proposed documentation of the feature (projects.yaml.md):

By default the inventories of all external projects defined in `projects.yaml`
will be downloaded. This can take a long time as it requires a network request
for each external project.

The `external_projects` configuration option can be set to a list with the names
of remote projects to fetch inventories from & enable links to.
The list must be a subset of the project names defined in `projects.yaml`.
The default value of `"all"` means to fetch all projects.

References to projects that are not in `external_projects` will not be resolved.
This applies to the terms of contents too, where unresolved references will
likely cause an error.

ref: #182

Based on #441, because I wanted to add tests too.