### PR TITLE
feat(doxygen.py): automatic setup of doxylink

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,9 @@ development = [
   "mypy>=1.3.0",
   "pip-tools>=6.13.0",
   "pre-commit>=3.3.2",
+  "pytest>=7.4.2",
   "ruff>=0.0.269",
-  "pytest>=7.4.2"
+  "sphinxcontrib.doxylink>=1.12.2"
 ]
 
 [project.entry-points."sphinx.html_themes"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -166,13 +166,17 @@ pyjwt[crypto]==2.8.0
 pynacl==1.5.0
     # via pygithub
 pyparsing==3.1.1
-    # via doxysphinx
+    # via
+    #   doxysphinx
+    #   sphinxcontrib-doxylink
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.2
     # via rocm-docs-core (pyproject.toml)
 python-dateutil==2.8.2
-    # via pygithub
+    # via
+    #   pygithub
+    #   sphinxcontrib-doxylink
 pytz==2023.3.post1
     # via babel
 pyyaml==6.0.1
@@ -209,6 +213,7 @@ sphinx==5.3.0
     #   sphinx-design
     #   sphinx-external-toc
     #   sphinx-notfound-page
+    #   sphinxcontrib-doxylink
 sphinx-book-theme==1.0.1
     # via rocm-docs-core (pyproject.toml)
 sphinx-copybutton==0.5.2
@@ -223,6 +228,8 @@ sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
+sphinxcontrib-doxylink==1.12.2
+    # via rocm-docs-core (pyproject.toml)
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx
 sphinxcontrib-jsmath==1.0.1

--- a/tests/sites/doxygen/extension/conf.py
+++ b/tests/sites/doxygen/extension/conf.py
@@ -1,5 +1,5 @@
 html_theme = "rocm_docs_theme"
-extensions = ["rocm_docs", "rocm_docs.doxygen"]
+extensions = ["rocm_docs", "rocm_docs.doxygen", "sphinxcontrib.doxylink"]
 
 doxygen_project = {
     "name": "Rocm Docs Core Doxygen Legacy Test Project",

--- a/tests/sites/doxygen/legacy/conf.py
+++ b/tests/sites/doxygen/legacy/conf.py
@@ -8,4 +8,9 @@ docs_core.enable_api_reference()
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)
 
+if not "extensions" in globals():
+    extensions = []
+
+extensions += ["sphinxcontrib.doxylink"]
+
 external_projects_current_project = "a"

--- a/tests/sites/templates/doxygen/.doxygen/A.cpp
+++ b/tests/sites/templates/doxygen/.doxygen/A.cpp
@@ -1,4 +1,13 @@
 /**
+ * \file
+ * \author Jon Doe (jon@example.com)
+ * \brief Test doxygen source
+ * \version 0.1
+ * \date 2023-03-23
+ * \copyright Copyright (c) 2023 Advanced Micro Devices Inc.
+ */
+
+/**
  * \brief Root namespace of the example project
  *
  */

--- a/tests/sites/templates/doxygen/.sphinx/_toc.yml.in
+++ b/tests/sites/templates/doxygen/.sphinx/_toc.yml.in
@@ -2,6 +2,7 @@ root: index.md
 entries:
   - file: a
   - file: breathe
+  - file: doxylink
   - file: .doxygen/docBin/html/index
     title: Doxygen API Reference
   - title: External Project A

--- a/tests/sites/templates/doxygen/doxylink.md
+++ b/tests/sites/templates/doxygen/doxylink.md
@@ -1,0 +1,8 @@
+# Test page for doxylink
+
+Test links to doxygen items:
+
+- File: {doxygen}`A.cpp`
+- Namespace: {doxygen}`my_project`
+- Class: {doxygen}`my_project::MyStruct`
+- Free function: {doxygen}`function_outside_group()`


### PR DESCRIPTION
**If** doxylink is enabled by the project
(by adding `sphinxcontrib.doxylink` to `extensions`) and `doxygen_html` is set, then set the settings of doxylink automatically. The role name is set to "doxygen", therefore references to the doxygen documentation in the current project can be typed as 
```
{doxygen}`entity-in-doxygen-doc`
```
which could be a file, functions, namespace etc.

This is only covers references within the same project, outside references will be done later.