### PR TITLE
docs(conf.py): add rocm to external_projects in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ setting_all_article_info = True
 # Disable fetching projects.yaml, it would be the same as the local one anyway
 # except if a PR modifies it. We want to test with its version in that case
 external_projects_remote_repository = ""
-external_projects = ["hipify", "python", "rocm-docs-core"]
+external_projects = ["hipify", "python", "rocm-docs-core", "rocm"]
 
 external_projects_current_project = "rocm-docs-core"
 


### PR DESCRIPTION
PR #443 broke linking.md, as it contains external an external reference to the main ROCm documentation page, so external_projects must mention it.