### PR TITLE
fix(projects): always resolve project references in TOC and templates

### DIFF
--- a/docs/developer_guide/projects_yaml.md
+++ b/docs/developer_guide/projects_yaml.md
@@ -52,6 +52,7 @@ of remote projects to fetch inventories from & enable links to.
 The list must be a subset of the project names defined in `projects.yaml`.
 The default value of `"all"` means to fetch all projects.
 
-References to projects that are not in `external_projects` will not be resolved.
-This applies to the terms of contents too, where unresolved references will
-likely cause an error.
+Intersphinx references to projects that are not in `external_projects` will not
+be resolved. References in the the TOC like `${project:project_name}` will
+continue to be resolved to the URL of `project_name`, even if `project_name` is
+not set in `external_projects` (but it's defined in `projects.yaml`).

--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -407,18 +407,18 @@ def _update_config(app: Sphinx, _: Config) -> None:
     current_project = _get_current_project(
         projects, app.config.external_projects_current_project
     )
-    default = _create_mapping(projects, current_project, branch)
-    external_projects = _get_external_projects(app, default)
+    remote_mapping = _create_mapping(projects, current_project, branch)
+    external_projects = _get_external_projects(app, remote_mapping)
 
     mapping: dict[str, ProjectMapping] = app.config.intersphinx_mapping
-    for key, value in default.items():
+    for key, value in remote_mapping.items():
         if key in external_projects:
             mapping.setdefault(key, value)
 
     if not config_provided_by_user(app, "external_toc_path"):
         app.config.external_toc_path = "./.sphinx/_toc.yml"  # type: ignore[attr-defined]
 
-    context = _get_context(Path(app.srcdir), mapping)
+    context = _get_context(Path(app.srcdir), remote_mapping)
     formatting.format_toc(
         Path(app.srcdir, app.config.external_toc_template_path),
         Path(app.srcdir, app.config.external_toc_path),

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -72,9 +72,9 @@ def test_external_projects(
     }
     assert app.config.intersphinx_mapping == expected_mapping
 
-    expected_context = {
-        k: v.target for k, v in mocked_projects.items() if k in keys
-    }
+    # Every project is available in the HTML templates and TOC, regardless of
+    # the value of "external_projects"
+    expected_context = {k: v.target for k, v in mocked_projects.items()}
     assert app.config.projects_context["projects"] == expected_context
 
 


### PR DESCRIPTION
Resolve project urls in jinja templates `projects["project_name"]` and in the TOC (`_toc.yml.in`) regardless of the setting of `external_projects`.

The HTML templates make use of the URL of the ROCm main project, which were broken with the previous behaviour. Having it available in the TOC too is more consistent, and there is no extra cost to it, as we already have this information from `projects.yaml` without downloading the sphinx inventories.