### PR TITLE
feat(doxygen.py): Enable doxygen extended toc with forked doxysphinx

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple, Union, cast
 
+import importlib.metadata
 import importlib.util
 import os
 import shutil
@@ -178,20 +179,20 @@ def _run_doxysphinx(
             '"pip install rocm-docs-core[api_reference]")'
         )
 
+    doxyphinx_version = importlib.metadata.version("doxysphinx")
+    args = [
+        sys.executable,
+        "-m",
+        "doxysphinx",
+        "build",
+        "--doxygen_exe=" + str(doxygen_exe.absolute()),
+    ]
+    if doxyphinx_version.endswith("+tagfile.toc"):
+        args.append("--tagfile_toc")
+    args += [app.srcdir, app.outdir, str(doxyfile)]
+
     try:
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "doxysphinx",
-                "build",
-                "--doxygen_exe=" + str(doxygen_exe.absolute()),
-                app.srcdir,
-                app.outdir,
-                doxyfile,
-            ],
-            cwd=doxygen_root,
-        )
+        subprocess.check_call(args, cwd=doxygen_root)
     except subprocess.CalledProcessError as err:
         raise RuntimeError(
             f"doxysphinx failed (exit code: {err.returncode})"


### PR DESCRIPTION
If the forked version of doxysphinx is detected, then enable the extended TOC based on the doxygen tagfile.
Projects that wish to use this have to replace their doxysphinx version in `requirements.in/txt` to the fork of doxysphinx that contains the necessary changes.

I.e. they should add:
`doxysphinx @ git+https://github.com/StreamHPC/doxysphinx.git@tagfile_toc`