### PR TITLE
Replace deprecated vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,10 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "bungcip.better-toml",
                 "ms-python.black-formatter",
                 "ms-python.python",
-                "ritwickdey.LiveServer"
+                "ritwickdey.LiveServer",
+                "tamasfe.even-better-toml"
             ]
         }
     }

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
 
 vscode:
   extensions:
-    - bungcip.better-toml
-    - ms-python.python
     - ms-python.black-formatter
+    - ms-python.python
     - ritwickdey.LiveServer
+    - tamasfe.even-better-toml


### PR DESCRIPTION
Better toml is deprecated and replaced by even better toml.