### PR TITLE
Swap themes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,7 @@ article_pages = [
 ]
 
 html_theme = "rocm_docs_theme"
+html_theme_options = {"flavor": "rocm-docs-home"}
 
 extensions = ["rocm_docs", "rocm_docs.doxygen"]
 doxygen_root = "demo/doxygen"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-from rocm_docs import ROCmDocs
-
 setting_all_article_info = True
 
 # Disable fetching projects.yaml, it would be the same as the local one anyway
@@ -27,15 +25,21 @@ article_pages = [
     {"file": "developer_guide/commitizen"},
 ]
 
-html_theme_options = {
-    "flavor": "rocm-docs-home"
+html_theme = "rocm_docs_theme"
+
+extensions = ["rocm_docs", "rocm_docs.doxygen"]
+doxygen_root = "demo/doxygen"
+doxysphinx_enabled = True
+doxygen_project = {
+    "name": "doxygen",
+    "path": "demo/doxygen/xml",
 }
-templates_path = ["."] # Use the current folder for templates
 
-docs_core = ROCmDocs("ROCm Docs Core")
-docs_core.run_doxygen(doxygen_root="demo/doxygen", doxygen_path=".")
-docs_core.enable_api_reference()
-docs_core.setup()
-
-for sphinx_var in ROCmDocs.SPHINX_VARS:
-    globals()[sphinx_var] = getattr(docs_core, sphinx_var)
+html_title = "ROCm Docs Core"
+project = "ROCm Docs Core"
+author = "Advanced Micro Devices, Inc."
+copyright = (
+    "Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved."
+)
+version = "0.30.0"
+release = "0.30.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,11 @@ article_pages = [
     {"file": "developer_guide/commitizen"},
 ]
 
+html_theme_options = {
+    "flavor": "rocm-docs-home"
+}
+templates_path = ["."] # Use the current folder for templates
+
 docs_core = ROCmDocs("ROCm Docs Core")
 docs_core.run_doxygen(doxygen_root="demo/doxygen", doxygen_path=".")
 docs_core.enable_api_reference()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ color = true
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.30.0"
-version_files = ["pyproject.toml:^version"]
+version_files = ["pyproject.toml:^version", "docs/conf.py:^(version|release)"]
 tag_format = "v$version"
 annotated_tag = true
 major_version_zero = true

--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -53,7 +53,6 @@ projects:
     development_branch: amd-master
   rocm: https://rocm.docs.amd.com/en/${version}
   rocm-docs-core: https://rocm.docs.amd.com/projects/rocm-docs-core/en/${version}
-  rocm-api-tools-list: https://rocm.docs.amd.com/en/${version}/reference/library-index.html
   rocm_smi_lib:
     target: https://rocm.docs.amd.com/projects/rocm_smi_lib/en/${version}
     development_branch: master

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-api-tools-list/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-api-tools-list/left-side-menu.jinja
@@ -1,3 +1,0 @@
-{%
-set main_doc_link = ("ROCm API & tools list", projects['rocm-api-tools-list'])
-%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/footer.jinja
@@ -1,0 +1,1 @@
+../rocm/footer.jinja

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/header.jinja
@@ -1,0 +1,1 @@
+../rocm/header.jinja

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-docs-home/left-side-menu.jinja
@@ -1,0 +1,3 @@
+{%
+set main_doc_link = ("ROCm Documentation Home", projects['rocm'])
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
@@ -1,3 +1,3 @@
 {%
-set main_doc_link = ("ROCm API & tools list", projects['rocm-api-tools-list'])
+set main_doc_link = ("ROCm API & tools list", projects['rocm'] ~ "/reference/library-index.html")
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
@@ -1,3 +1,3 @@
 {%
-set main_doc_link = ("ROCm Documentation Home", projects['rocm'])
+set main_doc_link = ("ROCm API & tools list", projects['rocm-api-tools-list'])
 %}

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -62,7 +62,7 @@ def _update_theme_options(app: Sphinx) -> None:
     theme_opts = get_theme_options_dict(app)
     _update_repo_opts(app.srcdir, theme_opts)
 
-    supported_flavors = ["rocm", "local", "rocm-api-tools-list"]
+    supported_flavors = ["rocm", "local", "rocm-docs-home"]
     flavor = theme_opts.get("flavor", "rocm")
     if flavor not in supported_flavors:
         logger.error(


### PR DESCRIPTION
relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/534 

Rename rocm-api-tools-list theme to rocm-docs-home

rocm theme left navbar points to api tools list page

rocm-docs-home left navbar points to rocm docs home page