### PR TITLE
fix(header.jinja): Fix support link in header for rocm-docs-core

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -13,6 +13,8 @@
 
 {% if theme_repository_url.endswith("-docs") %}
     {% set repo_url = theme_repository_url|replace("-docs", "") %}
+{% elif "rocm-install-on" in theme_repository_url %}
+    {% set repo_url = "https://github.com/ROCm/ROCm" %}
 {% else %}
     {% set repo_url = theme_repository_url %}
 {% endif %}
@@ -23,7 +25,7 @@ set nav_secondary_items = {
     "Community": "https://github.com/RadeonOpenCompute/ROCm/discussions",
     "AMD Lab Notes": "https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-readme/",
     "Infinity Hub": "https://www.amd.com/en/technologies/infinity-hub",
-    "Support": theme_repository_url|replace("-docs", "") + "/issues/new/choose",
+    "Support": repo_url + "/issues/new/choose",
     "Feedback": "mailto:rocm-feedback@amd.com"
 }
 %}


### PR DESCRIPTION
Also direct install doc repos to ROCm repo. Related to https://github.com/ROCm/ROCm/issues/2737#issuecomment-1876818280