### PR TITLE
Add merge mode to spellchecker and update to 0.52

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python3 .github/workflows/yaml_merger.py .spellcheck.yaml .spellcheck.local.yaml .spellcheck.yaml
       - name: Run spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.46.0
+        uses: rojopolis/spellcheck-github-actions@0.52.0
       - name: On fail
         if: failure()
         run: |


### PR DESCRIPTION
## Motivation

Currently, we can't exclude linting source from docs folder, for that we need an overwrite option.

## Technical Details

Add merge mode to spellchecker and update to 0.52.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
