### PR TITLE
ci: Update markdownlint-cli2-action: v20.0.0 → v14.0.0

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           test -f .markdownlint.yaml && echo "Using local config file" || curl --silent --show-error --fail --location https://raw.githubusercontent.com/ROCm/rocm-docs-core/develop/.markdownlint.yaml -O
       - name: Use markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v20.0.0
+        uses: DavidAnson/markdownlint-cli2-action@v14.0.0
         with:
           globs: "**/*.md"
 


### PR DESCRIPTION
## Motivation

The markdown linting false positive failed with higher versions.

## Technical Details

ci: Update markdownlint-cli2-action: v20.0.0 → v14.0.0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
