### PR TITLE
Remove continuous numbering of tables and figures

### DIFF
--- a/src/rocm_docs/core.py
+++ b/src/rocm_docs/core.py
@@ -80,7 +80,7 @@ class _DefaultSettings:
     external_toc_exclude_missing = _ConfigDefault(False)
     epub_show_urls = _ConfigDefault("footnote")
     exclude_patterns = _ConfigExtend(["_build", "Thumbs.db", ".DS_Store"])
-    numfig = _ConfigDefault(True)
+    numfig = _ConfigDefault(False)
     linkcheck_timeout = _ConfigDefault(10)
     linkcheck_request_headers = _ConfigMerge(
         {


### PR DESCRIPTION
## Motivation

This PR disables automatic numbering of figures and tables. Due to the way Sphinx works with numbers across subsections, these numbers can be inconsistent and confusing.

## Technical Details

Disables automatic numbering of figures and tables.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
