### PR TITLE
Override image paths for non-existent images

### DIFF
--- a/src/rocm_docs/data/_doxygen/doxygen-img-ref-fix.css
+++ b/src/rocm_docs/data/_doxygen/doxygen-img-ref-fix.css
@@ -1,0 +1,37 @@
+/**
+ * CSS workaround for Doxygen missing image references
+ *
+ * This file overrides CSS variables that reference non-existent images
+ * in the auto-generated doxygen.css file which makes the dead link checker
+ * happy.
+ */
+
+html {
+    /* Fix search images (not generated when SEARCHENGINE=NO) */
+    --search-magnification-image: none;
+    --search-magnification-select-image: none;
+    --nav-gradient-active-image-parent: none;
+
+    /* Fix fold/collapse images with incorrect relative paths (not generated when HTML_DYNAMIC_SECTIONS=NO) */
+    --fold-minus-image-relpath: none;
+    --fold-plus-image-relpath: none;
+}
+
+/* Dark mode overrides */
+@media (prefers-color-scheme: dark) {
+    html:not([data-theme=light]) {
+        --search-magnification-image: none;
+        --search-magnification-select-image: none;
+        --nav-gradient-active-image-parent: none;
+        --fold-minus-image-relpath: none;
+        --fold-plus-image-relpath: none;
+    }
+}
+
+html[data-theme=dark] {
+    --search-magnification-image: none;
+    --search-magnification-select-image: none;
+    --nav-gradient-active-image-parent: none;
+    --fold-minus-image-relpath: none;
+    --fold-plus-image-relpath: none;
+}


### PR DESCRIPTION
## Motivation

The CSS files generated by Doxygen reference images that aren't generated when certain Doxygen features are turned off in the Doxyfile. This makes the dead link checker unhappy.

## Technical Details

Adds a new CSS file which overrides the references found by the dead link checker.

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
