### PR TITLE
Ignore .cline_storage and .vscode directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /build
 /dist
 .DS_Store
+.cline_storage
+.vscode


### PR DESCRIPTION
## Motivation

Both VS Code and its Cline plugin create directories in the top-level directory which shouldn't be included in the git tree.

## Technical Details

Adds `.cline_storage` and `.vscode` to `.gitignore`.

## Test Plan

Tested locally.

## Test Result

Works.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
