### PR TITLE
chore: extend valid versions of ryzen at project.yml

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -82,7 +82,7 @@ projects:
   radeon:
     target: https://rocm.docs.amd.com/projects/radeon-ryzen/en/${version}
     development_branch: main
-    valid_versions: [docs-6.4.4, docs-6.4.2, docs-6.3.4, docs-6.3.2, docs-6.2.3, docs-6.1.3, docs-6.0.2, docs-5.7.0]
+    valid_versions: [docs-7.2, docs-7.1.1, docs-7.1, docs-7.0.2, docs-6.4.4, docs-6.4.2, docs-6.3.4, docs-6.3.2, docs-6.2.3, docs-6.1.3, docs-6.0.2, docs-5.7.0]
   rocal:
     target: https://rocm.docs.amd.com/projects/rocAL/en/${version}
     development_branch: develop


### PR DESCRIPTION
## Motivation

Extend valid versions of ryzen at project.yml

## Technical Details

The intershpinx use these valid version numbers.

## Test Plan

Not needed.

## Test Result

Not needed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
