### PR TITLE
fix(doxygen.py): access default config value through attribute access

### DIFF
--- a/src/rocm_docs/doxygen.py
+++ b/src/rocm_docs/doxygen.py
@@ -38,7 +38,7 @@ def _copy_files(app: Sphinx) -> None:
 
 def _get_config_default(config: Config, key: str) -> Any:
     """Get the default value for a sphinx configuration key."""
-    default_or_callable = config.values[key][0]
+    default_or_callable = config.values[key].default
     if callable(default_or_callable):
         return default_or_callable(config)
     return default_or_callable


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix the following warning when Sphinx < 9.
```
 RemovedInSphinx90Warning: The '_Opt' object tuple interface is deprecated, use attribute access instead for 'def
ault', 'rebuild', and 'valid_types'.
```

Fix the following error in Sphinx >= 9.
```
Traceback
=========

    Traceback (most recent call last):
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/sphinx/events.py", line 441, in emit
        results.append(listener.handler(self._app, *args))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/rocm_docs/doxygen.py", line 93, in _run_doxygen
        _update_breathe_settings(app, doxygen_root)
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/rocm_docs/doxygen.py", line 109, in _update_breathe_settings
        default: dict[str, None | str | os.PathLike[Any]] = _get_config_default(
                                                            ^^^^^^^^^^^^^^^^^^^^
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/rocm_docs/doxygen.py", line 41, in _get_config_default
        default_or_callable = config.values[key][0]
                              ~~~~~~~~~~~~~~~~~~^^^
    TypeError: '_Opt' object is not subscriptable
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/sphinx/cmd/build.py", line 414, in build_main
        app = Sphinx(
              ^^^^^^^
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/sphinx/application.py", line 325, in __init__
        self.events.emit('config-inited', self.config)
      File "/home/petepark/amd/venv312/lib/python3.12/site-packages/sphinx/events.py", line 452, in emit
        raise ExtensionError(
    sphinx.errors.ExtensionError: Handler <function _run_doxygen at 0x7344a17a3600> for event 'config-inited' threw an exception (exception: '_Opt' object is not subscriptable)
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Access the default configuration value using `values.default` instead of `values[0]`.

https://github.com/sphinx-doc/sphinx/commit/fd23cf0256bd401211ae3535206f48f7e28bca64#diff-5d140f836bc002529fa8bd76ae49b359f0546739c80e44a4c396fa5eb8d8e2d8R149 shows that `values[0]` == `values.default`

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Tested locally with Sphinx 8 (Python 3.10) and Sphinx 9 (Python 3.12)

## Test Result

<!-- Briefly summarize test outcomes. -->

No change in output. Warning is gone. Fixes build-blocking error if Sphinx >= 9.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
