### PR TITLE
ci: convert action version to commit hash

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fetch config
         shell: sh
         run: |
           test -f .markdownlint.yaml && echo "Using local config file" || curl --silent --show-error --fail --location https://raw.githubusercontent.com/ROCm/rocm-docs-core/develop/.markdownlint.yaml -O
       - name: Use markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@v14.0.0
+        uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
         with:
           globs: "**/*.md"
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Fetch config
         if: ${{ ! contains( github.repository, 'rocm-docs-core') }}
         shell: sh
@@ -54,7 +54,7 @@ jobs:
         run: |
           python3 .github/workflows/yaml_merger.py .spellcheck.yaml .spellcheck.local.yaml .spellcheck.yaml
       - name: Run spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.52.0
+        uses: rojopolis/spellcheck-github-actions@e3cd8e9aec4587ec73bc0e60745aafd45c37aa2e # v0.60.0
       - name: On fail
         if: failure()
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
       with:
-        just-version: '1.48.0'
+        just-version: '1.13.0'
     - name: Create virtual env, install requirements
       run: just deps
     - name: Check commit messages
@@ -86,7 +86,7 @@ jobs:
     - name: Install just
       uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
       with:
-        just-version: '1.48.0'
+        just-version: '1.13.0'
     - name: Create virtual env, install requirements
       run: just deps
     - name: Install

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,11 +12,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         python-version: "${{ matrix.python-version }}"
         cache: pip
@@ -24,7 +24,7 @@ jobs:
           pyproject.toml
           requirements.txt
     - name: Cache venv
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
         path: .venv
         key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml','requirements.txt') }}
@@ -33,14 +33,14 @@ jobs:
     - run: echo "PRE_COMMIT_HOME=$GITHUB_WORKSPACE/.cache/pre-commit" >> "$GITHUB_ENV"
       if: ${{ !startsWith(matrix.os, 'windows') }}
     - name: Cache pre-commit
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
         path: ${{ env.PRE_COMMIT_HOME }}
         key: pre-commit-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
     - name: Install just
-      uses: extractions/setup-just@v1
+      uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
       with:
-        just-version: '1.13.0'
+        just-version: '1.48.0'
     - name: Create virtual env, install requirements
       run: just deps
     - name: Check commit messages
@@ -58,11 +58,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ matrix.python-version }}"
         cache: pip
@@ -70,23 +70,23 @@ jobs:
           pyproject.toml
           requirements.txt
     - name: Set up Doxygen
-      uses: ssciwr/doxygen-install@v1.2.0
+      uses: ssciwr/doxygen-install@329d88f5a303066a5bd006db7516b1925b86350e # v2.0.1
       with:
         version: 1.9.8
     - name: Set up Graphviz
-      uses: ts-graphviz/setup-graphviz@v2.0.2
+      uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2
       with:
         ubuntu-graphviz-version: 2.42.2-9ubuntu0.1
         windows-graphviz-version: '9.0.0'
     - name: Cache venv
-      uses: actions/cache@v4.2.0
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
       with:
         path: .venv
         key: venv-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml','requirements.txt') }}
     - name: Install just
-      uses: extractions/setup-just@v1
+      uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
       with:
-        just-version: '1.13.0'
+        just-version: '1.48.0'
     - name: Create virtual env, install requirements
       run: just deps
     - name: Install

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ matrix.python-version }}"
         cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.revision || github.sha }}
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "${{ matrix.python-version }}"
         cache: pip
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install build==0.10.0
         python -m build
-    - uses: actions/upload-artifact@v4.3.6
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: dist-python${{ matrix.python-version }}
         path: dist
@@ -46,10 +46,10 @@ jobs:
     env:
       PYTHON_VERSION: "3.10"
     steps:
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: dist-python${{ env.PYTHON_VERSION }}
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.12.4
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,11 +19,11 @@ jobs:
       revision: ${{ steps.cz-bump.outputs.revision }}
       sha: ${{ steps.cz-bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
           cache: pip
@@ -31,7 +31,7 @@ jobs:
             pyproject.toml
             requirements.txt
       - name: Set up cache
-        uses: actions/cache@v4.2.0
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # 5.0.4
         with:
           path: .venv
           key: venv-${{ env.PYTHON_VERSION }}-${{ hashFiles('pyproject.toml','requirements.txt') }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -19,7 +19,7 @@ jobs:
       revision: ${{ steps.cz-bump.outputs.revision }}
       sha: ${{ steps.cz-bump.outputs.sha }}
     steps:
-      - uses: actions/checkout@@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
           cache: pip

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -38,7 +38,9 @@ def _get_rocm_toolkits() -> dict[str, str]:
     headers = {"User-Agent": "alexxu-amd"}
     while True:
         try:
-            response = requests.get(ROCM_TOOLKITS_URL, headers=headers, timeout=10)
+            response = requests.get(
+                ROCM_TOOLKITS_URL, headers=headers, timeout=10
+            )
             if response.status_code == 200:
                 return _parse_rocm_toolkits(response.text.strip())
         except requests.RequestException:


### PR DESCRIPTION
## Motivation

To mitigate trivy-action supply chain attack

## Technical Details

every github action is tied to a specific version. This version can be simply `v3.0` or the exact commit hash of that version i.e. `c903a7bdaee58ab217bb0ee005f17452ebac4433`. The former is more human-readable but has security concerns as an attacker can force-push to replace that version with malicious content and any pipeline that uses the version will be compromised, exposing repo secrets or other credentials.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
