### PR TITLE
ci: fix a linting error

### DIFF
--- a/.github/workflows/sync_repos.yml
+++ b/.github/workflows/sync_repos.yml
@@ -60,8 +60,8 @@ jobs:
         run: |
           branch=$(gh api "repos/${{ matrix.external }}" --jq '.default_branch')
           echo "name=$branch" >> "$GITHUB_OUTPUT"
-      
-      - name: Clean workfpace
+
+      - name: Clean workspace
         shell: sh
         run: rm -rf repo
 


### PR DESCRIPTION
## Motivation

A commit from a few days ago introduced trailing whitespace that makes the linter unhappy.

Also fixes a typo just after the offending line.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
