### PR TITLE
fix(css): primary and secondary sidebar z-indices

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -129,27 +129,8 @@ ul.bd-breadcrumbs li.breadcrumb-item {
   align-self: baseline;
 }
 
-.bd-sidebar-primary {
-  top: 3.5rem;
-  height: calc(100vh - 3.5rem);
-}
-
 .sbt-scroll-pixel-helper {
   top: 3.5rem !important;
-}
-
-@media (min-width: 576px) and (max-width: 959.98px) {
-  .bd-sidebar-primary {
-    top: 5.5rem;
-    height: calc(100vh - 5.5rem);
-  }
-}
-
-@media(min-width: 960px) {
-  .bd-sidebar-primary {
-    top: 0;
-    height: 100vh;
-  }
 }
 
 @media(min-width: 576px) {
@@ -220,6 +201,7 @@ a#ot-sdk-btn {
   }
 }
 
+.bd-sidebar-primary,
 .bd-sidebar-secondary {
   /* Header z-index is 2000, flyout z-index is 3000.
    * Setting sidebar's z-index to be between 2000 and 3000 to hover over the header without covering the flyout. */

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -4,8 +4,6 @@ header.common-header {
     font-size: 1rem;
     line-height: 1.5rem;
     margin-bottom: 0;
-/* readthedocs flyout z-index is 3000, setting header z-index to be below 3000 to avoid covering the flyout. */
-    z-index: 2000;
 }
 
 header.common-header a {

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -101,6 +101,7 @@ header.common-header .navbar.second-level-nav .header-nav-dropdown-toggle::after
   }
   header.common-header .navbar.second-level-nav .nav-item.dropdown .header-nav-dropdown-menu.show {
     display: block;
+    z-index: 2001;
   }
   header.common-header .navbar.second-level-nav .header-nav-dropdown-menu .dropdown-item {
     display: block;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Fix CSS rules related to `z-index` causing incorrect layering on mobile viewports (where the primary and secondary sidebars become collapsible).

<img width="949" height="1085" alt="image" src="https://github.com/user-attachments/assets/0e46850b-8462-48a3-b5d8-c0c003833bc6" />


## Technical Details

Remove unnecessary CSS rules that alter the z-index and position of the primary sidebar. Make the primary sidebar behave the same as the secondary sidebar on mobile displays -- more or less.

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

Test using mobile device emulation in Chrome devtools.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Looks ok.

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
