### PR TITLE
feat: add new flavor for Fluid Topics docs

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/footer.jinja
@@ -1,0 +1,1 @@
+{% macro license_link() -%}{%- endmacro -%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/header.jinja
@@ -1,0 +1,3 @@
+{% macro top_level_header(branch, latest_version, release_candidate_version) -%}{%- endmacro -%}
+{% macro version_list() -%}{%- endmacro -%}
+{% set nav_secondary_items = {} %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-ft/left-side-menu.jinja
@@ -1,0 +1,3 @@
+{%
+set main_doc_link = ("ROCm documentation", projects['rocm'])
+%}

--- a/src/rocm_docs/rocm_docs_theme/layout.html
+++ b/src/rocm_docs/rocm_docs_theme/layout.html
@@ -5,9 +5,13 @@
 {% endblock %}
 
 {% block docs_navbar %}
-    {%- include "sections/header.html" %}
+    {% if theme_flavor != "rocm-ft" %}
+        {%- include "sections/header.html" %}
+    {% endif %}
 {% endblock %}
 
 {%- block footer %}
-    {%- include "sections/footer.html" %}
+    {% if theme_flavor != "rocm-ft" %}
+        {%- include "sections/footer.html" %}
+    {% endif %}
 {%- endblock %}

--- a/src/rocm_docs/rocm_docs_theme/layout.html
+++ b/src/rocm_docs/rocm_docs_theme/layout.html
@@ -21,3 +21,9 @@
         {{ super() }}
     {% endif %}
 {% endblock %}
+
+{% block docs_sidebar %}
+    {% if theme_flavor != "rocm-ft" %}
+        {{ super() }}
+    {% endif %}
+{% endblock %}

--- a/src/rocm_docs/rocm_docs_theme/layout.html
+++ b/src/rocm_docs/rocm_docs_theme/layout.html
@@ -15,3 +15,9 @@
         {%- include "sections/footer.html" %}
     {% endif %}
 {%- endblock %}
+
+{% block docs_toc %}
+    {% if theme_flavor != "rocm-ft" %}
+        {{ super() }}
+    {% endif %}
+{% endblock %}

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -225,6 +225,11 @@ def _update_theme_options(app: Sphinx) -> None:
         flavor = supported_flavors[0]
         theme_opts["flavor"] = flavor
 
+    if flavor == "rocm-ft":
+        theme_opts["nosidebar"] = True
+        theme_opts["primary_sidebar_end"] = []
+        theme_opts["primary_sidebar_start"] = []
+
     # Set default generic theme options
     if flavor == "generic":
         theme_opts.setdefault("header_title", "")

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -234,6 +234,10 @@ def _update_theme_options(app: Sphinx) -> None:
         theme_opts.setdefault("license_link", None)
         theme_opts.setdefault("license_text", "")
 
+    if flavor == "rocm-ft":
+        theme_opts["nosidebar"] = True
+        theme_opts["primary_sidebar_end"] = []
+
     theme_opts.setdefault(
         "article_header_start",
         ["components/toggle-primary-sidebar.html", "breadcrumbs.html"],

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -214,6 +214,7 @@ def _update_theme_options(app: Sphinx) -> None:
         "rocm-finance",
         "rocm-simulation",
         "rocm-llmext",
+        "rocm-ft",
     ]
     flavor = theme_opts.get("flavor", "rocm")
     if flavor not in supported_flavors:

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -234,10 +234,6 @@ def _update_theme_options(app: Sphinx) -> None:
         theme_opts.setdefault("license_link", None)
         theme_opts.setdefault("license_text", "")
 
-    if flavor == "rocm-ft":
-        theme_opts["nosidebar"] = True
-        theme_opts["primary_sidebar_end"] = []
-
     theme_opts.setdefault(
         "article_header_start",
         ["components/toggle-primary-sidebar.html", "breadcrumbs.html"],


### PR DESCRIPTION
## Motivation

When publishing on Fluid Topics, standard ROCm flavor's header and footer gets disorganized

## Technical Details

Create a new flavor without header and footer for Fluid Topics NDA docs

## Test Plan

Using ROCm-internal as an example to adapt to this flavor, checkout the output

## Test Result

https://rocm-stg.amd.com/en/alexxu12-nda-flavor-test/

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
