### PR TITLE
feat: recognize X.Y.Z-preview slugs as static intersphinx versions

### DIFF
--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -45,6 +45,7 @@ ProjectMapping: TypeAlias = tuple[str, Inventory]
 DEFAULT_INTERSPHINX_REPOSITORY = "ROCm/rocm-docs-core"
 DEFAULT_INTERSPHINX_BRANCH = "develop"
 DOCS_VERSION_PATTERN = r"^docs-\d+\.\d+\.\d+$"
+PREVIEW_VERSION_PATTERN = r"^\d+\.\d+\.\d+-preview$"
 
 logger = sphinx.util.logging.getLogger(__name__)
 
@@ -162,6 +163,11 @@ class _Project:
         # Past release versions always with docs/
         regex = re.compile(DOCS_VERSION_PATTERN)
         if regex.match(current_branch):
+            return current_branch
+
+        # Pre-release preview builds (e.g. 7.13.0-preview) link to the matching
+        # preview version on each sister project.
+        if re.match(PREVIEW_VERSION_PATTERN, current_branch):
             return current_branch
 
         # Anything besides the canonical development branch links to latest docs

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -174,3 +174,21 @@ def test_set_doxygen_html_mismatched(expect_log: ExpectLogFixture) -> None:
             app, rocm_docs.projects._Project("", [], "", [], "does-not-match")
         )
     assert app.config.doxygen_html == "must-not-be-changed"
+
+
+@pytest.mark.parametrize(
+    ("current_branch", "expected"),
+    [
+        ("latest", "latest"),
+        ("stable", "stable"),
+        ("docs-7.2.0", "docs-7.2.0"),
+        ("7.13.0-preview", "7.13.0-preview"),
+        ("8.0.0-preview", "8.0.0-preview"),
+        ("some-feature-branch", "latest"),
+    ],
+)
+def test_get_static_version(current_branch: str, expected: str) -> None:
+    assert (
+        rocm_docs.projects._Project.get_static_version(current_branch, None)
+        == expected
+    )


### PR DESCRIPTION
## Problem

`_Project.get_static_version` (`src/rocm_docs/projects.py:148`) decides what to substitute for `${version}` in intersphinx target URLs. It only passes the slug through if it matches `^docs-\d+\.\d+\.\d+$` (the `DOCS_VERSION_PATTERN` at line 47), is `latest`/`stable`, or equals the development branch. Everything else falls through to `return "latest"`.

This breaks preview cycles. On the active ROCm 7.13.0 preview, the ROCm-internal RTD version is `7.13.0-preview` and each sister project (HIP, RCCL, hipBLASLt, composable-kernel, etc.) has a matching `7.13.0-preview` build. But intersphinx URLs from the preview emit `/en/latest/` on every sister project because `7.13.0-preview` doesn't match the regex.

## Fix

Add `PREVIEW_VERSION_PATTERN = r"^\d+\.\d+\.\d+-preview$"` and pass the slug through unchanged when it matches, alongside the existing `docs-X.Y.Z` handling. Preview slugs already have separate theme handling at `_update_theme_configs` (`projects.py:439` uses `current_branch.endswith("preview")`), so the concept is already recognized — this just extends it to URL resolution.

## Test

Adds a parametrized `test_get_static_version` covering the existing cases (`latest`, `stable`, `docs-X.Y.Z`, generic branch → `latest`) and the new preview cases (`7.13.0-preview`, `8.0.0-preview`). All 6 cases pass locally.

## Notes

- Pattern is intentionally narrow (`<X.Y.Z>-preview`) to match how preview slugs are currently named across ROCm projects. Open to widening if maintainers prefer a more general rule.
- Once released and pinned in `ROCm-internal/docs/sphinx/requirements.in`, the matching monkey-patch in https://github.com/ROCm/ROCm-internal/pull/795 can be removed.
