### PR TITLE
fix(article_info.py): fix massive read time bug from hipDF

### DIFF
--- a/src/rocm_docs/article_info.py
+++ b/src/rocm_docs/article_info.py
@@ -190,7 +190,8 @@ def _estimate_read_time(file_name: Path) -> str:
     with open(file_name, encoding="utf-8") as file:
         html = file.read()
     soup = bs4.BeautifulSoup(html, "html.parser")
-    page_text = soup.find_all(text=True)
+    article = soup.find("article") or soup.find("main") or soup
+    page_text = article.find_all(text=True)
     visible_page_text = filter(is_visible, page_text)
     average_word_count = sum(count_words(line) for line in visible_page_text)
     time_minutes = int(max(1, round(average_word_count / words_per_minute)))


### PR DESCRIPTION
## Motivation

hipDF has a 150 word page showing 21mins read time

<img width="769" height="727" alt="image" src="https://github.com/user-attachments/assets/1d77e8ef-66c4-4304-808a-7cf3f5843fe0" />


## Technical Details

Word estimate was calculated based on all html items, including TOC and massive API references

## Test Plan

Build hipDF using the patch locally

## Test Result

<img width="887" height="723" alt="image" src="https://github.com/user-attachments/assets/36de7eeb-335d-4393-ab76-d730ec182162" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
