### PR TITLE
Update ai-developer-hub to v14.0

### DIFF
--- a/latest_version.txt
+++ b/latest_version.txt
@@ -1,5 +1,5 @@
 rocm: 7.2.4
-ai-developer-hub: v13.0
+ai-developer-hub: v14.0
 rocm-ds: 25.10
 rocm-ls: 26.03
 rocm-simulation: 25.11


### PR DESCRIPTION
Updates the `ai-developer-hub` version variable from `v13.0` to `v14.0` following the v14.0 GA publication sync to the public [gpuaidev](https://github.com/ROCm/gpuaidev) repo. This change directs the RTD `latest` alias to the new release branch once it is added in RTD settings.