### PR TITLE
feat: Add AI Ecosystem theme and improve global nav bar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "breathe>=4.34.0",
   "myst-nb>=1.1.2",
   "pydata-sphinx-theme>=0.15.4",
-  "sphinx-book-theme>=1.1.4",
+  "sphinx-book-theme==1.1.4",
   "sphinx-copybutton>=0.5.1",
   "sphinx-design>=0.3.0",
   "sphinx_external_toc>=0.3.1",

--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -20,6 +20,9 @@ projects:
   cvs:
     target: https://rocm.docs.amd.com/projects/cvs/en/${version}
     development_branch: main
+  ai-ecosystem:
+    target: https://rocm.docs.amd.com/projects/ai-ecosystem/en/${version}
+    development_branch: main
   gpuaidev:
     target: https://rocm.docs.amd.com/projects/ai-developer-hub/en/${version}
     development_branch: main

--- a/src/rocm_docs/projects.py
+++ b/src/rocm_docs/projects.py
@@ -442,8 +442,6 @@ def _update_theme_configs(
         app.config.projects_version_type = util.VersionType.ROCM_LATEST_RELEASE
     elif flavor != "rocm" and current_branch in latest_version_string_list:
         app.config.projects_version_type = util.VersionType.OTHER_LATEST_RELEASE
-    elif current_branch.endswith("preview"):
-        app.config.projects_version_type = util.VersionType.PREVIEW
     elif current_branch.startswith(release_candidate_string):
         app.config.projects_version_type = util.VersionType.RELEASE_CANDIDATE
     elif re.match(doc_branch_pattern, current_branch):

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/footer.jinja
@@ -1,0 +1,3 @@
+{% macro license_link() -%}
+    <li><a href="{{ projects['rocm'] ~ "/about/license.html" }}">ROCm Licenses and Disclaimers</a></li>
+{%- endmacro -%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
@@ -1,0 +1,37 @@
+{% macro top_level_header(branch, latest_version, release_candidate_version) -%}
+    <a class="klavika-font hover-opacity" href="{{ projects['ai-ecosystem'] }}">ROCm&#8482; AI Ecosystem</a>
+{%- endmacro -%}
+
+{% macro version_list() -%}
+{%- endmacro -%}
+
+{% if theme_repository_url.endswith("-docs") %}
+    {% set repo_url = theme_repository_url|replace("-docs", "") %}
+{% else %}
+    {% set repo_url = theme_repository_url %}
+{% endif %}
+
+{% set repo_url = repo_url|replace("http://", "https://") %}
+
+{%
+set nav_secondary_items = {
+    "ROCm Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
+    "ROCm Toolkits": header_rocm_toolkits,
+}
+%}
+
+{%
+set nav_item_classes = {
+    "AI Ecosystem": "fw-bold",
+}
+%}
+
+{%
+set nav_secondary_items_end = {
+    "Blogs": "https://rocm.blogs.amd.com/",
+    "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
+    "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
+}
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
@@ -15,10 +15,10 @@
 
 {%
 set nav_secondary_items = {
-    "ROCm Core SDK": "https://rocm.docs.amd.com",
-    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "Core SDK": "https://advanced-micro-devices-rocm-internal--802.com.readthedocs.build/en/803/",
+    "AI Ecosystem": "https://advanced-micro-devices-rocm-internal--802.com.readthedocs.build/en/802/",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
-    "ROCm Toolkits": header_rocm_toolkits,
+    "Toolkits": header_rocm_toolkits,
 }
 %}
 
@@ -31,7 +31,6 @@ set nav_item_classes = {
 {%
 set nav_secondary_items_end = {
     "Blogs": "https://rocm.blogs.amd.com/",
-    "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
-    "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
+    "Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
 }
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/header.jinja
@@ -15,8 +15,8 @@
 
 {%
 set nav_secondary_items = {
-    "Core SDK": "https://advanced-micro-devices-rocm-internal--802.com.readthedocs.build/en/803/",
-    "AI Ecosystem": "https://advanced-micro-devices-rocm-internal--802.com.readthedocs.build/en/802/",
+    "Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
     "Toolkits": header_rocm_toolkits,
 }

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/left-side-menu.jinja
@@ -1,3 +1,3 @@
 {%
-set main_doc_link = ("ROCm AI Ecosystem documentation", projects['ai-ecosystem'])
+set main_doc_link = ("ROCm AI Ecosystem", projects['ai-ecosystem'])
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/ai-ecosystem/left-side-menu.jinja
@@ -1,0 +1,3 @@
+{%
+set main_doc_link = ("ROCm AI Ecosystem documentation", projects['ai-ecosystem'])
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
@@ -21,12 +21,23 @@
 {%- endmacro -%}
 
 {%
-set nav_secondary_items = theme_nav_secondary_items if theme_nav_secondary_items else {
-    "GitHub": theme_repository_url if theme_repository_url else "#",
-    "Community": "https://github.com/ROCm/ROCm/discussions",
+set nav_secondary_items = {
+    "Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
+    "Toolkits": header_rocm_toolkits,
+}
+%}
+
+{%
+set nav_item_classes = {
+    "AI Ecosystem": "fw-bold",
+}
+%}
+
+{%
+set nav_secondary_items_end = {
     "Blogs": "https://rocm.blogs.amd.com/",
-    "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
-    "ROCm&#8482; Docs": "https://rocm.docs.amd.com",
-    "Support": (theme_repository_url + "/issues/new/choose") if theme_repository_url else "#"
+    "Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
 }
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/instinct/header.jinja
@@ -11,7 +11,6 @@
     <a class="klavika-font hover-opacity" href="{{ projects['instinct'] }}">GPU Systems and Infrastructure</a>
 {%- endmacro -%}
 
-
 {% set repo_url = repo_url|replace("http://", "https://") %}
 
 {% macro version_list() -%}
@@ -31,9 +30,10 @@ set nav_secondary_items = {
 
 {%
 set nav_item_classes = {
-    "AI Ecosystem": "fw-bold",
+    "GPU Systems and Infrastructure": "fw-bold",
 }
 %}
+
 
 {%
 set nav_secondary_items_end = {

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -24,12 +24,6 @@
 {% set repo_url = repo_url|replace("http://", "https://") %}
 
 {%
-set nav_item_classes = {
-    "Core SDK": "fw-bold",
-}
-%}
-
-{%
 set nav_secondary_items = {
     "Core SDK": "https://rocm.docs.amd.com",
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
@@ -37,6 +31,13 @@ set nav_secondary_items = {
     "Toolkits": header_rocm_toolkits,
 }
 %}
+
+{%
+set nav_item_classes = {
+    "Core SDK": "fw-bold",
+}
+%}
+
 
 {%
 set nav_secondary_items_end = {

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -25,23 +25,22 @@
 
 {%
 set nav_item_classes = {
-    "ROCm Core SDK": "fw-bold",
+    "Core SDK": "fw-bold",
 }
 %}
 
 {%
 set nav_secondary_items = {
-    "ROCm Core SDK": "https://rocm.docs.amd.com",
+    "Core SDK": "https://rocm.docs.amd.com",
     "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
     "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
-    "ROCm Toolkits": header_rocm_toolkits,
+    "Toolkits": header_rocm_toolkits,
 }
 %}
 
 {%
 set nav_secondary_items_end = {
     "Blogs": "https://rocm.blogs.amd.com/",
-    "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
-    "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
+    "Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
 }
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/header.jinja
@@ -8,7 +8,7 @@
     {% else %}
         {% set version_name = branch.replace('-', ' ').title() %}
     {% endif %}
-    <a class="klavika-font hover-opacity" href="{{ projects['rocm'] }}">ROCm&#8482; Software {{ version_name }}</a>
+    <a class="klavika-font hover-opacity" href="{{ projects['rocm'] }}">ROCm&#8482; Core SDK {{ version_name }}</a>
 {%- endmacro -%}
 
 {% macro version_list() -%}
@@ -24,14 +24,24 @@
 {% set repo_url = repo_url|replace("http://", "https://") %}
 
 {%
+set nav_item_classes = {
+    "ROCm Core SDK": "fw-bold",
+}
+%}
+
+{%
 set nav_secondary_items = {
-    "GitHub": repo_url,
-    "Community": "https://github.com/ROCm/ROCm/discussions",
+    "ROCm Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
+    "ROCm Toolkits": header_rocm_toolkits,
+}
+%}
+
+{%
+set nav_secondary_items_end = {
     "Blogs": "https://rocm.blogs.amd.com/",
     "ROCm Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
-    "AMD Toolkits": header_rocm_toolkits,
-    "Systems and Infra Docs": "https://instinct.docs.amd.com",
     "Infinity Hub": "https://www.amd.com/en/developer/resources/infinity-hub.html",
-    "Support": repo_url + "/issues/new/choose",
 }
 %}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm/left-side-menu.jinja
@@ -1,3 +1,3 @@
 {%
-set main_doc_link = ("ROCm documentation", projects['rocm'])
+set main_doc_link = ("ROCm Core SDK", projects['rocm'])
 %}

--- a/src/rocm_docs/rocm_docs_theme/sections/header.html
+++ b/src/rocm_docs/rocm_docs_theme/sections/header.html
@@ -3,6 +3,8 @@
         nav_secondary_items, top_level_header, version_list
     with context
     %}
+{%- from "flavors/" ~ theme_flavor ~ "/header.jinja" import nav_secondary_items_end with context -%}
+{%- from "flavors/" ~ theme_flavor ~ "/header.jinja" import nav_item_classes with context -%}
 
     <header class="common-header" >
         <nav class="navbar navbar-expand-xl">
@@ -35,11 +37,48 @@
         <nav class="navbar navbar-expand-xl second-level-nav">
             <div class="container-fluid main-nav">
                 <div class="navbar-nav-container collapse navbar-collapse" id="navbarSupportedContent">
+                    {% if nav_secondary_items_end %}
+                    <div class="d-flex w-100 align-items-stretch">
+                        <ul class="navbar-nav nav-mega mb-2 mb-lg-0">
+                            {% for name, url_or_items in nav_secondary_items.items() %}
+                            <li class="nav-item{% if url_or_items is mapping %} dropdown{% endif %}">
+                                {% if url_or_items is string %}
+                                    <a class="nav-link top-level header-menu-links{{ ' ' ~ nav_item_classes[name] if nav_item_classes and name in nav_item_classes else '' }}" href="{{ url_or_items }}" id="nav{{ name.lower()|replace(' ','-') }}" role="button" aria-expanded="false" target="_blank">{{ name }}</a>
+                                {% elif url_or_items is mapping %}
+                                    <a class="nav-link top-level header-menu-links dropdown-toggle header-nav-dropdown-toggle" href="#" id="nav{{ name.lower()|replace(' ','-') }}" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ name }}</a>
+                                    <ul class="dropdown-menu header-nav-dropdown-menu" aria-labelledby="nav{{ name.lower()|replace(' ','-') }}">
+                                        {% for item_name, item_url in url_or_items.items() %}
+                                            <li><a class="dropdown-item" href="{{ item_url }}" target="_blank">{{ item_name }}</a></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        <div class="nav-group-separator"></div>
+                        <ul class="navbar-nav nav-mega mb-2 mb-lg-0">
+                            {% for name, url_or_items in nav_secondary_items_end.items() %}
+                            <li class="nav-item{% if url_or_items is mapping %} dropdown{% endif %}">
+                                {% if url_or_items is string %}
+                                    <a class="nav-link top-level header-menu-links{{ ' ' ~ nav_item_classes[name] if nav_item_classes and name in nav_item_classes else '' }}" href="{{ url_or_items }}" id="nav{{ name.lower()|replace(' ','-') }}" role="button" aria-expanded="false" target="_blank">{{ name }}</a>
+                                {% elif url_or_items is mapping %}
+                                    <a class="nav-link top-level header-menu-links dropdown-toggle header-nav-dropdown-toggle" href="#" id="nav{{ name.lower()|replace(' ','-') }}" role="button" data-bs-toggle="dropdown" aria-expanded="false">{{ name }}</a>
+                                    <ul class="dropdown-menu header-nav-dropdown-menu" aria-labelledby="nav{{ name.lower()|replace(' ','-') }}">
+                                        {% for item_name, item_url in url_or_items.items() %}
+                                            <li><a class="dropdown-item" href="{{ item_url }}" target="_blank">{{ item_name }}</a></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% else %}
                     <ul class="navbar-nav nav-mega me-auto mb-2 mb-lg-0 col-xl-10">
                         {% for name, url_or_items in nav_secondary_items.items() %}
                             <li class="nav-item{% if url_or_items is mapping %} dropdown{% endif %}">
                                 {% if url_or_items is string %}
-                                    <a class="nav-link top-level header-menu-links" href="{{ url_or_items }}" id="nav{{ name.lower()|replace(' ','-') }}" role="button" aria-expanded="false" target="_blank" >
+                                    <a class="nav-link top-level header-menu-links{{ ' ' ~ nav_item_classes[name] if nav_item_classes and name in nav_item_classes else '' }}" href="{{ url_or_items }}" id="nav{{ name.lower()|replace(' ','-') }}" role="button" aria-expanded="false" target="_blank" >
                                         {{ name }}
                                     </a>
                                 {% elif url_or_items is mapping %}
@@ -55,6 +94,7 @@
                             </li>
                         {% endfor %}
                     </ul>
+                    {% endif %}
                 </div>
             </div>
         </nav>

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -164,6 +164,14 @@ ul.bd-breadcrumbs li.breadcrumb-item {
   }
 }
 
+.header-article-items__start {
+  display: flex;
+}
+
+.bd-header-article .article-header-buttons {
+  align-items: start;
+}
+
 .bd-sidebar-primary .sidebar-header-items {
   display: flex;
   flex-direction: column;
@@ -319,8 +327,4 @@ article :not(p) img {
 
 #rocm-banner {
   color: #80dfff;
-}
-
-.bd-header-article .article-header-buttons {
-  align-items: center;
 }

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -320,3 +320,7 @@ article :not(p) img {
 #rocm-banner {
   color: #80dfff;
 }
+
+.bd-header-article .article-header-buttons {
+  align-items: center;
+}

--- a/src/rocm_docs/rocm_docs_theme/static/custom.css
+++ b/src/rocm_docs/rocm_docs_theme/static/custom.css
@@ -228,12 +228,6 @@ a#ot-sdk-btn {
   }
 }
 
-.bd-sidebar-secondary {
-  /* Header z-index is 2000, flyout z-index is 3000.
-   * Setting sidebar's z-index to be between 2000 and 3000 to hover over the header without covering the flyout. */
-  z-index: 2001;
-}
-
 .sd-card-body.rocm-card-banner {
   padding-top: 0;
   padding-left: 0;

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -1011,14 +1011,14 @@ header.common-header
 
 header.common-header .navbar.second-level-nav .nav-group-separator {
     width: 2px;
-    height: 1.75rem;
     background-color: rgba(255, 255, 255, 0.3);
     flex-shrink: 0;
-    align-self: center;
 }
 
 @media (min-width: 1200px) {
     header.common-header .navbar.second-level-nav .nav-group-separator {
+        align-self: center;
+        height: 1.75rem;
         margin-right: 3rem;
     }
 }

--- a/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
+++ b/src/rocm_docs/rocm_docs_theme/static/rocm_header.css
@@ -1008,3 +1008,17 @@ header.common-header
       width: 60%;
   }
 }
+
+header.common-header .navbar.second-level-nav .nav-group-separator {
+    width: 2px;
+    height: 1.75rem;
+    background-color: rgba(255, 255, 255, 0.3);
+    flex-shrink: 0;
+    align-self: center;
+}
+
+@media (min-width: 1200px) {
+    header.common-header .navbar.second-level-nav .nav-group-separator {
+        margin-right: 3rem;
+    }
+}

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -186,10 +186,6 @@ def _update_banner(
         announcement_info = "This is not the latest version of ROCm documentation. See <a id='rocm-banner' href='https://rocm.docs.amd.com/en/latest/'>ROCm documentation</a> for the latest version."
     elif version_type == util.VersionType.DEVELOPMENT:
         announcement_info = "This page contains proposed changes for a future release of ROCm. Read the <a id='rocm-banner' href='https://rocm.docs.amd.com/en/latest/'>latest Linux release of ROCm documentation</a> for your production environments."
-    elif version_type == util.VersionType.PREVIEW:
-        announcement_info = f"This is ROCm {preview_version} technology preview release documentation. For production use, refer to <a id='rocm-banner' href='https://rocm.docs.amd.com/en/latest/'>ROCm {latest_version} documentation</a>."
-    elif version_type == util.VersionType.ROCM_LATEST_RELEASE:
-        announcement_info = f"The ROCm {preview_version} technology preview release documentation is available at <a id='rocm-banner' href='https://rocm.docs.amd.com/en/{preview_version}-preview/'>ROCm Preview documentation</a>. For production use, continue to use ROCm {latest_version} documentation."
 
     theme_opts.setdefault("announcement", announcement_info)
 

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -208,6 +208,7 @@ def _update_theme_options(app: Sphinx) -> None:
         "generic",
         "rocm-ds",
         "ai-developer-hub",
+        "ai-ecosystem",
         "rocm-ls",
         "gsplat",
         "rocm-rag",

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -169,7 +169,10 @@ def _update_banner(
     if flavor != "rocm":
         return
 
-    if version_type == util.VersionType.ROCM_LATEST_RELEASE or version_type == util.VersionType.OTHER_LATEST_RELEASE:
+    if (
+        version_type == util.VersionType.ROCM_LATEST_RELEASE
+        or version_type == util.VersionType.OTHER_LATEST_RELEASE
+    ):
         return
 
     announcement_info: str

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -173,13 +173,6 @@ def _update_banner(
         return
 
     announcement_info: str
-    preview_version = _get_version_from_url(
-        "https://raw.githubusercontent.com/ROCm/rocm-docs-core/new_data/preview_version.txt"
-    )
-    latest_version_string = _get_version_from_url(
-        "https://raw.githubusercontent.com/ROCm/rocm-docs-core/new_data/latest_version.txt"
-    )
-    latest_version = _parse_version(latest_version_string).get("rocm", "latest")
     if version_type == util.VersionType.RELEASE_CANDIDATE:
         announcement_info = "This page contains changes for a test release of ROCm. Read the <a id='rocm-banner' href='https://rocm.docs.amd.com/en/latest/'>latest Linux release of ROCm documentation</a> for your production environments."
     elif version_type == util.VersionType.OLD_RELEASE:

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -169,7 +169,7 @@ def _update_banner(
     if flavor != "rocm":
         return
 
-    if version_type == util.VersionType.OTHER_LATEST_RELEASE:
+    if version_type == util.VersionType.ROCM_LATEST_RELEASE or version_type == util.VersionType.OTHER_LATEST_RELEASE:
         return
 
     announcement_info: str

--- a/src/rocm_docs/util.py
+++ b/src/rocm_docs/util.py
@@ -24,7 +24,6 @@ class VersionType(enum.Enum):
     OTHER_LATEST_RELEASE = enum.auto()
     OLD_RELEASE = enum.auto()
     RELEASE_CANDIDATE = enum.auto()
-    PREVIEW = enum.auto()
 
 
 def get_path_to_docs(


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->


## Technical Details

  - New ai-ecosystem flavor — adds a new theme flavor for the ROCm AI Ecosystem docs, based on the rocm flavor. Includes a simplified top-level header (no version display), license footer, and
  left-side-menu pointing to projects['ai-ecosystem'].
  - Split secondary nav — introduces a two-group layout for the secondary nav bar. Flavors can now define nav_secondary_items (left group) and nav_secondary_items_end (right group), separated by a
  styled vertical divider. Flavors that only define nav_secondary_items fall back to the original single-group layout unchanged.
  - Per-item nav classes — flavors can define a nav_item_classes dict to apply extra CSS classes (e.g. Bootstrap's fw-bold) to individual nav links by name, without requiring flavor-specific CSS.
  - Updated rocm flavor — restructured secondary nav to use the split layout: left group contains ROCm Core SDK, AI Ecosystem, GPU Systems and Infrastructure, and ROCm Toolkits (with "ROCm Core SDK"
  bolded); right group contains GitHub, Community, Blogs, ROCm Developer Hub, Infinity Hub, and Support.
  - Separator styling — added .nav-group-separator styles to the global rocm_header.css: 2px wide, 1.75rem tall, centered vertically, with extra right-side margin at wide viewports (≥1200px) to match
   the nav item padding rhythm.


- Remove "GitHub" from the global header nav.

  Update conf.py in each project's Sphinx config to enable the GitHub button.
  https://sphinx-book-theme.readthedocs.io/en/stable/components/source-files.html

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
