### PR TITLE
fix: set left nav default for new docs flavor

### DIFF
--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -225,6 +225,9 @@ def _update_theme_options(app: Sphinx) -> None:
         theme_opts["primary_sidebar_end"] = []
         theme_opts["primary_sidebar_start"] = []
 
+    if flavor == "hyperloom":
+        theme_opts.setdefault("link_main_doc", False)
+
     # Set default generic theme options
     if flavor == "generic":
         theme_opts.setdefault("header_title", "")


### PR DESCRIPTION
Sets the default left navigation behavior for the new docs flavor added in the previous PR, so component sites using the flavor get the correct navigation behavior out of the box without needing to configure it in their own `conf.py`.