### PR TITLE
fix: link portal header title to the current project index

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/hyperloom/header.jinja
@@ -1,5 +1,5 @@
 {% macro top_level_header(branch, latest_version, release_candidate_version) -%}
-    <a class="klavika-font hover-opacity" href="{{ projects['hyperloom'] }}">{{ project }} {{ version }}</a>
+    <a class="klavika-font hover-opacity" href="{{ pathto(root_doc) }}">{{ project }} {{ version }}</a>
 {%- endmacro -%}
 
 


### PR DESCRIPTION
## Summary
In the shared portal header, the project title on the left (`{{ project }} {{ version }}`) was hardcoded to link to a single fixed portal index for every site that uses this flavor. On component sites this sent users to the wrong index page instead of their own.

This changes the title link to `pathto(root_doc)`, the standard Sphinx idiom for the current build's own index, so each site's header title links to its own landing page.

## Test plan
- [ ] Build a component doc site with this flavor and confirm the header title links to that site's own index
- [ ] Build the main portal site and confirm the header title still resolves to its index