### PR TITLE
fix: add rocm-extras flavor

### DIFF
--- a/src/rocm_docs/data/projects.yaml
+++ b/src/rocm_docs/data/projects.yaml
@@ -109,6 +109,7 @@ projects:
     development_branch: develop
   rocjpeg: https://rocm.docs.amd.com/projects/rocJPEG/en/${version}
   rocm: https://rocm.docs.amd.com/en/${version}
+  rocm-extras: https://rocm.docs.amd.com/en/${version}/components/extras.html
   rocm-docs-core: https://rocm.docs.amd.com/projects/rocm-docs-core/en/${version}
   hyperloom:
     target: https://rocm.docs.amd.com/projects/hyperloom/en/${version}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/footer.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/footer.jinja
@@ -1,0 +1,3 @@
+{% macro license_link() -%}
+    <li><a href="{{ projects['rocm'] ~ "/about/license.html" }}">ROCm Licenses and Disclaimers</a></li>
+{%- endmacro -%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/header.jinja
@@ -1,0 +1,37 @@
+{% macro top_level_header(branch, latest_version, release_candidate_version) -%}
+    {% set header_title = theme_header_title if theme_header_title else project ~ " " ~ version %}
+    {% set header_link  = theme_header_link  if theme_header_link  else "#" %}
+    <a class="klavika-font hover-opacity" href="{{ header_link }}">{{ header_title }}</a>
+{%- endmacro -%}
+
+{% macro version_list() -%}
+    <a class="header-all-versions hover-opacity" href="https://rocm.docs.amd.com/en/latest/release/versions.html">Version List</a>
+{%- endmacro -%}
+
+{% if theme_repository_url.endswith("-docs") %}
+    {% set repo_url = theme_repository_url|replace("-docs", "") %}
+{% else %}
+    {% set repo_url = theme_repository_url %}
+{% endif %}
+
+{% set repo_url = repo_url|replace("http://", "https://") %}
+
+{%
+set nav_secondary_items = {
+    "Core SDK": "https://rocm.docs.amd.com",
+    "AI Ecosystem": "https://rocm.docs.amd.com/projects/ai-ecosystem",
+    "GPU Systems and Infrastructure": "https://instinct.docs.amd.com",
+    "Toolkits": header_rocm_toolkits,
+}
+%}
+
+{%
+set nav_item_classes = {}
+%}
+
+{%
+set nav_secondary_items_end = {
+    "Blogs": "https://rocm.blogs.amd.com/",
+    "Developer Hub": "https://www.amd.com/en/developer/resources/rocm-hub.html",
+}
+%}

--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/left-side-menu.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/left-side-menu.jinja
@@ -1,0 +1,3 @@
+{%
+set main_doc_link = ("ROCm Extras", "https://rocm.docs.amd.com/en/latest/components/extras.html")
+%}

--- a/src/rocm_docs/theme.py
+++ b/src/rocm_docs/theme.py
@@ -210,6 +210,7 @@ def _update_theme_options(app: Sphinx) -> None:
         "rocm-llmext",
         "rocm-ft",
         "hyperloom",
+        "rocm-extras",
     ]
     flavor = theme_opts.get("flavor", "rocm")
     if flavor not in supported_flavors:


### PR DESCRIPTION
Adds a new `rocm-extras` flavor for component documentation sites under the ROCm Extras umbrella.

- Header title and link are configurable from each component's `conf.py` via `header_title` and `header_link`
- Left sidebar hub link reads **ROCm Extras** and points to `https://rocm.docs.amd.com/en/latest/components/extras.html`
- Nav strip and footer match the `rocm` flavor
- Flavor registered in `supported_flavors` in `theme.py`
- `rocm-extras` entry added to `projects.yaml`