### PR TITLE
fix: use version_list_link from conf.py in rocm-extras flavor

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/header.jinja
+++ b/src/rocm_docs/rocm_docs_theme/flavors/rocm-extras/header.jinja
@@ -5,7 +5,9 @@
 {%- endmacro -%}
 
 {% macro version_list() -%}
-    <a class="header-all-versions hover-opacity" href="https://rocm.docs.amd.com/en/latest/release/versions.html">Version List</a>
+    {% if theme_version_list_link %}
+        <a class="header-all-versions hover-opacity" href="{{ theme_version_list_link }}">Version List</a>
+    {% endif %}
 {%- endmacro -%}
 
 {% if theme_repository_url.endswith("-docs") %}


### PR DESCRIPTION
The `rocm-extras` flavor was hardcoding the ROCm-wide version list URL. Since this flavor is shared across multiple components, each with its own version history, the `version_list` macro should read `version_list_link` from the component's `conf.py` instead.