### PR TITLE
fix(theme): remove jQuery dependency from static JS

### DIFF
--- a/src/rocm_docs/rocm_docs_theme/static/code_word_breaks.js
+++ b/src/rocm_docs/rocm_docs_theme/static/code_word_breaks.js
@@ -1,22 +1,40 @@
-$(document).ready(() => {
-    const copy = async(event) => {
-        return await navigator.clipboard.writeText($(event.target).attr('copydata'));
+(function () {
+    "use strict";
+
+    function init() {
+        const copy = async (element) => {
+            return await navigator.clipboard.writeText(
+                element.getAttribute("copydata")
+            );
+        };
+
+        document.querySelectorAll(".table td code").forEach((el) => {
+            const text = el.textContent;
+            el.classList.add("hovertext");
+            el.setAttribute("copydata", text);
+            el.setAttribute("data-hover", "Click to copy.");
+            const newText = text
+                .replaceAll(/_([^\u200B])/g, "_\u200B$1")
+                .replaceAll(/([a-z])([A-Z])/g, "$1\u200B$2");
+            el.textContent = newText;
+            el.addEventListener("click", (event) => {
+                copy(event.target);
+                event.target.setAttribute("data-hover", "Copied!");
+                const onMouseLeave = () => {
+                    event.target.setAttribute("data-hover", "Click to copy.");
+                    event.target.removeEventListener(
+                        "mouseleave",
+                        onMouseLeave
+                    );
+                };
+                event.target.addEventListener("mouseleave", onMouseLeave);
+            });
+        });
     }
 
-    $('.table td code').each( function () {
-        var text = $(this).text()
-        $(this).addClass('hovertext')
-        $(this).attr('copydata', text)
-        $(this).attr('data-hover', "Click to copy.")
-        var new_text = text.replaceAll(/_([^\u200B])/g, '_\u200B$1').replaceAll(/([a-z])([A-Z])/g, '$1\u200B$2')
-        $(this).text(new_text)
-        $(this).click((event) => {
-            copy(event)
-            $(event.target).attr('data-hover', "Copied!")
-            $(event.target).on("mouseleave", () => {
-                $(event.target).attr('data-hover', "Click to copy.")
-                $(event.target).off("mouseleave")
-            })
-        })
-    })
-})
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/src/rocm_docs/rocm_docs_theme/static/rdcMisc.js
+++ b/src/rocm_docs/rocm_docs_theme/static/rdcMisc.js
@@ -1,90 +1,155 @@
-function fixBreadcrumbItems() {
-    const breadcrumbItems = $("li.breadcrumb-item:not(.breadcrumb-home,.active)");
-    const breadcrumbBox = $("ul.bd-breadcrumbs")
-    breadcrumbBox.data("maxWidth", 0)
+(function () {
+    "use strict";
+
+    function cssWidth(el) {
+        const style = getComputedStyle(el);
+        const paddingX =
+            parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+        const borderX =
+            parseFloat(style.borderLeftWidth) +
+            parseFloat(style.borderRightWidth);
+        return el.getBoundingClientRect().width - paddingX - borderX;
+    }
+
+    function cssHeight(el) {
+        const style = getComputedStyle(el);
+        const paddingY =
+            parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+        const borderY =
+            parseFloat(style.borderTopWidth) +
+            parseFloat(style.borderBottomWidth);
+        return el.getBoundingClientRect().height - paddingY - borderY;
+    }
+
+    function lines(el) {
+        const lineHeight = parseFloat(getComputedStyle(el).lineHeight);
+        return Math.round(cssHeight(el) / lineHeight);
+    }
+
     function adjustLength(item, container, factor, getTextItem) {
         const textItem = getTextItem(item);
-        const lines = (x) => Math.round(x.height() / parseFloat(x.css('line-height').replace('px', '')))
+        if (!textItem) {
+            return;
+        }
+
         function getMaxWidth(container, itm) {
             const startLines = lines(container);
-            const initialText = itm.text();
-            let maxWidth = container.width();
-            while (lines(container) == startLines) {
-                itm.text(itm.text() + "\u200B.");
-                if (container.width() > maxWidth) {
-                    maxWidth = container.width()
+            const initialText = itm.textContent;
+            let maxWidth = cssWidth(container);
+            while (lines(container) === startLines) {
+                itm.textContent = itm.textContent + "\u200B.";
+                if (cssWidth(container) > maxWidth) {
+                    maxWidth = cssWidth(container);
                 }
             }
-            itm.text(initialText);
+            itm.textContent = initialText;
             return maxWidth;
         }
-        const containerMaxWidth = container.data("maxWidth") || getMaxWidth(container, textItem);
-        container.data("maxWidth", containerMaxWidth)
-        const fullText = item.data("fullText") || textItem.text();
-        item.data("fullText", fullText);
-        textItem.text(fullText)
-        if (lines(item) == 1 && item.width() < containerMaxWidth * factor) {
+
+        const containerMaxWidth =
+            container.__maxWidth || getMaxWidth(container, textItem);
+        container.__maxWidth = containerMaxWidth;
+        const fullText = item.__fullText || textItem.textContent;
+        item.__fullText = fullText;
+        textItem.textContent = fullText;
+        if (lines(item) === 1 && cssWidth(item) < containerMaxWidth * factor) {
             return;
         }
         const words = fullText.split(/\s/);
         let newText = words[0];
         for (let i = 1; i < words.length; i++) {
-            textItem.text(newText + " " + words[i] + "...");
-            if (lines(item) == 1 && item.width() < containerMaxWidth * factor) {
+            textItem.textContent = newText + " " + words[i] + "...";
+            if (
+                lines(item) === 1 &&
+                cssWidth(item) < containerMaxWidth * factor
+            ) {
                 newText += " " + words[i];
             } else {
                 break;
             }
         }
         newText += "...";
-        textItem.text(newText);
+        textItem.textContent = newText;
     }
-    breadcrumbItems.each(function () {
-        adjustLength($(this), breadcrumbBox, 0.82 * (breadcrumbItems.length <= 2 ? 1 : 0.5), x => x.children('a'))
-    })
-    adjustLength($("li.breadcrumb-item.active"), breadcrumbBox, 0.95, x => x);
-    breadcrumbBox.data("maxWidth", 0);
-}
 
-$(document).ready(function () {
-    if (window.ResizeObserver) {
-        document.body.addEventListener("bodyresize", event => {
-            const { contentRect } = event.detail;
-            const { width } = contentRect;
-            if (window.prevWidth) {
+    function fixBreadcrumbItems() {
+        const breadcrumbItems = document.querySelectorAll(
+            "li.breadcrumb-item:not(.breadcrumb-home, .active)"
+        );
+        const breadcrumbBox = document.querySelector("ul.bd-breadcrumbs");
+        if (!breadcrumbBox) {
+            return;
+        }
+        breadcrumbBox.__maxWidth = 0;
+        breadcrumbItems.forEach((item) => {
+            adjustLength(
+                item,
+                breadcrumbBox,
+                0.82 * (breadcrumbItems.length <= 2 ? 1 : 0.5),
+                (x) => x.querySelector(":scope > a")
+            );
+        });
+        const activeItem = document.querySelector(
+            "li.breadcrumb-item.active"
+        );
+        if (activeItem) {
+            adjustLength(activeItem, breadcrumbBox, 0.95, (x) => x);
+        }
+        breadcrumbBox.__maxWidth = 0;
+    }
 
-            }
-            if ((window.prevWidth && window.prevWidth > 960) && width < 960) {
-                $("input#__primary").prop("checked", false);
-            }
-            window.prevWidth = width;
-            fixBreadcrumbItems();
-        })
-
-        const onResizeCallback = (() => {
-            let initial = true;
-            let timeout;
-            return entries => {
-                if (initial) {
-                    initial = false;
-                    return;
-                }
-                clearTimeout(timeout)
-                timeout = setTimeout(() => {
-                    for (const entry of entries) {
-                        const event = new CustomEvent('bodyresize', {
-                            detail: entry
-                        });
-                        entry.target.dispatchEvent(event);
+    function init() {
+        if (window.ResizeObserver) {
+            document.body.addEventListener("bodyresize", (event) => {
+                const { contentRect } = event.detail;
+                const { width } = contentRect;
+                if (
+                    window.prevWidth &&
+                    window.prevWidth > 960 &&
+                    width < 960
+                ) {
+                    const primaryToggle = document.querySelector(
+                        "input#__primary"
+                    );
+                    if (primaryToggle) {
+                        primaryToggle.checked = false;
                     }
-                }, 200);
-            }
-        })()
+                }
+                window.prevWidth = width;
+                fixBreadcrumbItems();
+            });
 
-        window.resizeObserver = new ResizeObserver(onResizeCallback)
-        window.resizeObserver.observe(document.body);
-    } else {
-        console.error("ResizeObserver not supported.")
+            const onResizeCallback = (() => {
+                let initial = true;
+                let timeout;
+                return (entries) => {
+                    if (initial) {
+                        initial = false;
+                        return;
+                    }
+                    clearTimeout(timeout);
+                    timeout = setTimeout(() => {
+                        for (const entry of entries) {
+                            const event = new CustomEvent("bodyresize", {
+                                detail: entry,
+                            });
+                            entry.target.dispatchEvent(event);
+                        }
+                    }, 200);
+                };
+            })();
+
+            window.resizeObserver = new ResizeObserver(onResizeCallback);
+            window.resizeObserver.observe(document.body);
+        } else {
+            console.error("ResizeObserver not supported.");
+        }
+        fixBreadcrumbItems();
     }
-    fixBreadcrumbItems();
-})
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/src/rocm_docs/rocm_docs_theme/static/renameVersionLinks.js
+++ b/src/rocm_docs/rocm_docs_theme/static/renameVersionLinks.js
@@ -1,27 +1,37 @@
-function renameVersionLinks() {
-    $('div.rst-other-versions dl:first-child a').each( function () {
-        const text = $(this).text();
-        const versionRegEx = /^.*((?:[0-9]+\.){2}[0-9]+).*$/g;
-        if (versionRegEx.test(text)) {
-            $(this).text(text.replace(versionRegEx, '$1'));
-        }
-    })
-}
+(function () {
+    "use strict";
 
-function waitForSelector(selector, callback, backoff=100, max=15) {
-    let tries = 0;
-    const waitInterval = setInterval(() => {
-        if ($(selector).length > 0) {
-            callback()
-            clearInterval(waitInterval)
-        } else {
-            if (tries++ > max) {
-                clearInterval(waitInterval)
+    function renameVersionLinks() {
+        document
+            .querySelectorAll("div.rst-other-versions dl:first-child a")
+            .forEach((el) => {
+                const text = el.textContent;
+                const versionRegEx = /^.*((?:[0-9]+\.){2}[0-9]+).*$/g;
+                if (versionRegEx.test(text)) {
+                    el.textContent = text.replace(versionRegEx, "$1");
+                }
+            });
+    }
+
+    function waitForSelector(selector, callback, backoff = 100, max = 15) {
+        let tries = 0;
+        const waitInterval = setInterval(() => {
+            if (document.querySelector(selector)) {
+                callback();
+                clearInterval(waitInterval);
+            } else if (tries++ > max) {
+                clearInterval(waitInterval);
             }
-        }
-    }, backoff)
-}
+        }, backoff);
+    }
 
-$(document).ready(() => {
-    waitForSelector('div.rst-versions', renameVersionLinks);
-})
+    function init() {
+        waitForSelector("div.rst-versions", renameVersionLinks);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/src/rocm_docs/rocm_docs_theme/static/theme_mode_captions.js
+++ b/src/rocm_docs/rocm_docs_theme/static/theme_mode_captions.js
@@ -1,18 +1,30 @@
-function modifyThemeModeCaptions() {
-    var themeSwitchButtons = document.getElementsByClassName("theme-switch-button");
-    for (var i = 0; i < themeSwitchButtons.length; i++) {
-        themeSwitchButtons[i].setAttribute("data-bs-original-title", document.documentElement.dataset.mode);
+(function () {
+    "use strict";
+
+    function modifyThemeModeCaptions() {
+        const themeSwitchButtons = document.getElementsByClassName(
+            "theme-switch-button"
+        );
+        for (let i = 0; i < themeSwitchButtons.length; i++) {
+            themeSwitchButtons[i].setAttribute(
+                "data-bs-original-title",
+                document.documentElement.dataset.mode
+            );
+        }
     }
-}
 
-function addModeListener() {
-    const btn = document.getElementsByClassName("theme-switch-button")[0];
-    btn.addEventListener("click", modifyThemeModeCaptions);
-}
+    function addModeListener() {
+        const btn = document.getElementsByClassName(
+            "theme-switch-button"
+        )[0];
+        if (btn) {
+            btn.addEventListener("click", modifyThemeModeCaptions);
+        }
+    }
 
-$(addModeListener);
-$(window).ajaxComplete(function() {
-    setTimeout(() => {
-        modifyThemeModeCaptions();
-    }, 3000);
-})
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", addModeListener);
+    } else {
+        addModeListener();
+    }
+})();


### PR DESCRIPTION
## Issue

`rocm_docs_theme`'s static JS — `code_word_breaks.js`, `renameVersionLinks.js`,
`rdcMisc.js`, and `theme_mode_captions.js` — references the jQuery global `$`,
but `pydata-sphinx-theme` (a `rocm-docs-core` dependency, currently pinned
`>=0.15.4`) hasn't shipped jQuery since it was dropped upstream in v0.13.0
(Feb 2023, [[pydata/pydata-sphinx-theme#1029](https://github.com/pydata/pydata-sphinx-theme/pull/1029)],
"Drop jQuery and use Bootstrap 5"). Every page load throws
`ReferenceError: $ is not defined` from all four files.

I noticed these errors when testing via Playwright-based console validation during the `instinct-design` flavor development.

## Fix

Rewrote all four files to plain DOM APIs, no jQuery:

- `code_word_breaks.js` / `renameVersionLinks.js` — mechanical translation to
  `querySelectorAll`/`classList`/native event listeners, same behavior.
- `rdcMisc.js` — breadcrumb truncation math needed adjusting along the way:
  jQuery's `.width()`/`.height()` always normalized to content-box, while
  `getComputedStyle()` reflects `box-sizing: border-box` under
  pydata-sphinx-theme's Bootstrap 5 reset, which was inflating measured width
  and shifting the truncation threshold. Now computed via
  `getBoundingClientRect()` minus padding/border to match the original
  content-box semantics.
- `theme_mode_captions.js` — drops the `$(window).ajaxComplete(...)` handler;
  there's no jQuery-driven AJAX left in this environment for it to observe,
  and the existing click listener already keeps the caption in sync on
  user-initiated theme toggles.

## Scope / risk

A repo-wide check confirms these are the only four files in
`rocm_docs_theme`'s own static assets referencing jQuery syntax — `search.js`
and the newer `instinct-design.js` are already jQuery-free. All four affected
behaviors are cosmetic UX affordances (code-cell copy + word-break
formatting, version-dropdown label cleanup, breadcrumb truncation + sidebar
auto-collapse, theme-toggle tooltip caption) — none touch search, navigation,
or content rendering, so functional risk from the rewrite is low.

A secondary `bootstrap.js` `getBoundingClientRect` `TypeError` reported
alongside this is from pydata-sphinx-theme's own vendored Bootstrap bundle,
not this theme's code — out of scope here; worth a separate upstream report
against pydata-sphinx-theme if it still reproduces once this lands.

## Verification

Exercised via a standalone HTML harness with representative
breadcrumb/table/version-dropdown/theme-switch markup, run through Playwright
in a headless browser: zero console errors, and all four behaviors confirmed
working (click-to-copy, word-break insertion, breadcrumb truncation,
version-link renaming, theme-mode caption update).